### PR TITLE
Streamline module heroes and fuel entry flow

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,963 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+:root,
+[data-theme="light"] {
+  --accent-h: 222;
+  --accent-s: 83%;
+  --accent-l: 53%;
+  --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
+  --accent-weak: hsl(var(--accent-h) 60% 94%);
+  --bg: #f5f6fb;
+  --surface: #f8f9fc;
+  --card: #ffffff;
+  --ink: #0f172a;
+  --muted: #667085;
+  --line: #e2e7f0;
+  --shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.08);
+  --shadow: 0 12px 30px -24px rgb(15 23 42 / 0.2);
+  --shadow-md: 0 16px 40px -24px rgb(15 23 42 / 0.24);
+  --shadow-lg: 0 28px 60px -32px rgb(15 23 42 / 0.24);
+  --green: #059669;
+  --green-soft: #dcfce7;
+  --red: #dc2626;
+  --red-soft: #fee2e2;
+  --orange: #ea580c;
+  --orange-soft: #ffedd5;
+  --blue: #2563eb;
+  --blue-soft: #dbeafe;
+  --purple: #7c3aed;
+  --yellow: #facc15;
+  --radius-sm: 10px;
+  --radius: 16px;
+  --radius-lg: 24px;
+  --transition: 0.18s ease;
+
+  /* Legacy tokens used by sub-modules */
+  --primary: var(--accent);
+  --primary-dark: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) - 10%));
+  --primary-light: hsl(var(--accent-h) 90% 92%);
+  --primary-lighter: hsl(var(--accent-h) 100% 97%);
+  --success: var(--green);
+  --success-light: var(--green-soft);
+  --error: var(--red);
+  --error-light: var(--red-soft);
+  --warning: var(--orange);
+  --warning-light: var(--orange-soft);
+  --info: var(--blue);
+  --info-light: var(--blue-soft);
+  --bg-secondary: var(--surface);
+  --sidebar-bg: #101727;
+  --text-primary: var(--ink);
+  --text-secondary: var(--muted);
+  --text-tertiary: #94a3b8;
+  --border: var(--line);
+  --border-light: #f1f5f9;
+  --radius-xl: 28px;
+  --gradient-hero: radial-gradient(1200px 400px at 20% -10%, hsl(var(--accent-h) 80% 92%) 0%, transparent 55%),
+                    radial-gradient(1000px 500px at 80% -20%, hsl(280 70% 95%) 0%, transparent 50%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover {
+  color: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 6%));
+}
+
+.wrap {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  position: relative;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  border-color: hsl(var(--accent-h) 40% 80% / 0.6);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.title {
+  margin: 0 0 12px 0;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.2px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.ink {
+  color: var(--ink);
+}
+
+.tiny {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.page-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 800;
+}
+
+.page-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--accent-weak);
+  color: hsl(var(--accent-h) 35% 35%);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid hsl(var(--accent-h) 45% 80% / 0.6);
+  width: fit-content;
+}
+
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.module-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.module-hero {
+  background: var(--gradient-hero);
+  border-bottom: 1px solid var(--line);
+  padding: 18px 0 14px;
+}
+
+.module-hero .wrap {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.module-hero-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.module-hero-top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.module-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.module-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.module-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: hsl(var(--accent-h) 35% 28%);
+}
+
+.module-title {
+  margin: 0;
+  font-size: clamp(22px, 3.2vw, 28px);
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.module-subtitle {
+  margin: 0;
+  font-size: 12px;
+  color: hsl(var(--accent-h) 18% 35% / 0.85);
+  max-width: 520px;
+}
+
+.module-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.module-hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.module-hero-stat {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: var(--card);
+  box-shadow: var(--shadow-sm);
+  min-width: 180px;
+}
+
+.module-hero-stat .emoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.module-hero-stat .stat-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.module-hero-stat .label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  text-transform: none;
+}
+
+.module-hero-stat .value,
+.module-hero-stat .big-number {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.module-hero-stat .note {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.module-hero-stat.positive {
+  border-color: var(--green-soft);
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.module-hero-stat.positive .label,
+.module-hero-stat.positive .note {
+  color: rgba(22, 101, 52, 0.8);
+}
+
+.module-hero-stat.negative {
+  border-color: var(--red-soft);
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.module-hero-stat.negative .label,
+.module-hero-stat.negative .note {
+  color: rgba(185, 28, 28, 0.8);
+}
+
+.module-hero-stat.neutral {
+  border-color: var(--accent-weak);
+  background: var(--surface);
+}
+
+.module-content {
+  flex: 1;
+  padding-bottom: 56px;
+}
+
+.module-content .wrap {
+  padding-top: 24px;
+}
+
+.page-tabs,
+.tabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--line);
+  padding: 8px 0 12px;
+  margin-bottom: 20px;
+}
+
+.tab,
+.page-tab {
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.tab:hover,
+.page-tab:hover {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.tab.active,
+.page-tab.active {
+  background: var(--card);
+  border-color: var(--line);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+.btn.soft {
+  background: var(--surface);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--muted);
+}
+
+.btn.danger {
+  background: var(--red);
+  color: #fff;
+  border-color: transparent;
+}
+
+.btn.link {
+  background: transparent;
+  border-color: transparent;
+  color: var(--blue);
+  padding: 0;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--card);
+  color: var(--ink);
+  font: inherit;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 60% / 0.2);
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+}
+
+.g-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.g-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.g-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 1024px) {
+  .g-4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .g-2,
+  .g-3,
+  .g-4 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stat-card .label {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.stat-card .value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.stat-card .note {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.chart-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chart-card .title {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.chart-area {
+  position: relative;
+  min-height: 240px;
+}
+
+.ok {
+  color: var(--green);
+}
+
+.bad {
+  color: var(--red);
+}
+
+.warn {
+  color: var(--orange);
+}
+
+.table,
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 10px 8px;
+  border-top: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+  font-size: 13px;
+}
+
+thead th {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--accent-h) 40% 82% / 0.6);
+  background: var(--accent-weak);
+  font-size: 12px;
+  color: hsl(var(--accent-h) 32% 32%);
+  font-weight: 600;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.section-heading .title {
+  margin: 0;
+}
+
+.card-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.empty-state {
+  padding: 24px;
+  text-align: center;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.divider {
+  height: 1px;
+  background: var(--line);
+  margin: 24px 0;
+}
+
+@media (max-width: 768px) {
+  .module-hero {
+    padding: 28px 0 22px;
+  }
+
+  .module-hero-top {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .module-hero-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .module-hero-meta {
+    align-items: flex-start;
+  }
+
+  .module-content .wrap {
+    padding: 24px 20px 48px;
+  }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: hsl(var(--accent-h) 35% 75% / 0.6);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 60% / 0.35);
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn.soft {
+  background: var(--surface);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--line);
+}
+
+.btn.danger {
+  background: var(--red);
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn.tiny {
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 10px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 9px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 13px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 60% / 0.18);
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+}
+
+.g-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.g-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.g-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 1100px) {
+  .g-4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .g-2,
+  .g-3,
+  .g-4 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+
+.stat-card,
+.surface-card {
+  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stat-card .label {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-card .value {
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.stat-card .trend {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.pill,
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--accent-h) 45% 85% / 0.6);
+  background: var(--accent-weak);
+  font-size: 11px;
+  font-weight: 600;
+  color: hsl(var(--accent-h) 32% 32%);
+  white-space: nowrap;
+}
+
+.badge.success {
+  background: var(--green-soft);
+  border-color: hsl(152 76% 85%);
+  color: var(--green);
+}
+
+.badge.danger {
+  background: var(--red-soft);
+  border-color: hsl(0 80% 85%);
+  color: var(--red);
+}
+
+.badge.warn {
+  background: var(--orange-soft);
+  border-color: hsl(26 90% 85%);
+  color: var(--orange);
+}
+
+.table-wrapper {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--card);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+thead th {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--surface);
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+tbody tr:hover {
+  background: var(--surface);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.progress {
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress > i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 0.5s ease;
+}
+
+.tag-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.list-clean {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-clean li + li {
+  margin-top: 10px;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.card.fade-in {
+  animation: fadeInUp 0.35s ease both;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--accent-h) 30% 70% / 0.6);
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@media (max-width: 720px) {
+  .wrap {
+    padding: 24px 16px 40px;
+  }
+  .page-header {
+    margin-bottom: 20px;
+  }
+  .card {
+    padding: 18px;
+  }
+}

--- a/budget.html
+++ b/budget.html
@@ -4,150 +4,380 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Budżet (ulepszona wersja)</title>
-  <style>
-    :root{
-      --bg:#f8fafc;--card:#fff;--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;
-      --green:#059669;--red:#be123c;--orange:#ea580c;--blue:#0369a1
+  <link rel="stylesheet" href="assets/styles.css">
+    <style>
+    .row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
     }
-    *{box-sizing:border-box}
-    body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto}
-    .wrap{max-width:1200px;margin:0 auto;padding:24px}
-    .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.03)}
-    .row{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
-    .muted{color:var(--muted)}
-    .title{margin:0 0 8px 0;font-weight:700}
-    .pill{display:inline-block;padding:2px 8px;background:#f1f5f9;border:1px solid var(--line);border-radius:999px;font-size:12px;color:#475569}
-    .btn{display:inline-flex;gap:8px;align-items:center;border-radius:12px;padding:8px 12px;border:1px solid #0f172a;background:#0f172a;color:#fff;cursor:pointer; text-decoration: none;}
-    .btn.soft{background:#f1f5f9;border-color:#e2e8f0;color:#0f172a}
-    .btn.danger{background:#ffe4e6;border-color:#fecdd3;color:#b91c1c}
-    .btn.ghost{background:transparent;color:#0f172a;border-color:var(--line)}
-    .btn.link{background:transparent;border:0;color:#0369a1;cursor:pointer;padding:0}
-    .tabs{display:flex;gap:8px;flex-wrap:wrap;position:sticky;top:0;background:var(--bg);padding:8px 0;z-index:10}
-    .tab{padding:6px 10px;border-radius:10px;border:1px solid var(--line);cursor:pointer;background:#fff}
-    .tab.active{background:#0f172a;color:#fff;border-color:#0f172a}
-    table{width:100%;border-collapse:collapse}
-    th,td{padding:8px;border-top:1px solid var(--line);text-align:left;vertical-align:middle}
-    input,select,textarea{border:1px solid var(--line);border-radius:10px;padding:8px;background:#fff;color:#0f172a;width:100%}
-    input::placeholder{color:#94a3b8}
-    .grid{display:grid;gap:12px}
-    .g-2{grid-template-columns:repeat(2,minmax(0,1fr))}
-    .g-3{grid-template-columns:repeat(3,minmax(0,1fr))}
-    .g-4{grid-template-columns:repeat(4,minmax(0,1fr))}
-    @media(max-width:900px){.g-2,.g-3,.g-4{grid-template-columns:1fr}}
-    .ok{color:var(--green)}.bad{color:var(--red)}.warn{color:var(--orange)}
-    .progress{height:8px;background:#e2e8f0;border-radius:999px;overflow:hidden}
-    .progress>i{display:block;height:100%;background:#0f172a}
-    .progress.good>i{background:var(--green)}
-    .progress.warn>i{background:var(--orange)}
-    .stat-card{background:#f8fafc;border:1px solid var(--line);border-radius:12px;padding:12px}
-    .big-number{font-weight:800;font-size:28px}
-    .trend{font-size:12px;color:var(--muted);margin-top:4px}
-    .chart-box{height:240px}
-    .quick-actions .quick-btn{display:flex;flex-direction:column;gap:2px;border:1px dashed var(--line);border-radius:12px;padding:10px;cursor:pointer; text-align:center; transition: all .2s}
-    .quick-actions .quick-btn:hover{border-style:solid; border-color:var(--blue); background:#eff6ff}
-    .heat-day{width:22px;height:22px;border-radius:4px;display:grid;place-items:center;font-size:10px}
-    .heat-legend{display:flex;gap:6px;align-items:center;font-size:12px;color:#64748b}
-    .editor-section{border:1px dashed var(--line);border-radius:12px;padding:12px;margin-top:10px;background:#f8fafc}
-    .qa-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
-    @media(max-width:900px){.qa-grid{grid-template-columns:1fr 1fr}}
-    .tiny{font-size:12px;color:var(--muted)}
-    .split-box{border:1px dashed var(--line);padding:8px;border-radius:10px;background:#f8fafc}
-    .banner{background:#ecfeff;border:1px solid #cffafe;border-radius:12px;padding:10px}
-    .hint{font-size:12px;color:#64748b}
+
+    .budget-tabs {
+      position: sticky;
+      top: 0;
+      background: var(--bg);
+      z-index: 8;
+      padding: 8px 0;
+      margin-bottom: 0;
+    }
+
+    .trend {
+      font-size: 12px;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+
+    .progress {
+      height: 8px;
+      background: #e2e8f0;
+      border-radius: 999px;
+      overflow: hidden;
+    }
+
+    .progress > i {
+      display: block;
+      height: 100%;
+      background: var(--ink);
+    }
+
+    .progress.good > i { background: var(--green); }
+    .progress.warn > i { background: var(--orange); }
+
+    .chart-box {
+      height: 240px;
+      position: relative;
+    }
+
+    .chart-box.tall { height: 320px; }
+    .chart-box.wide { height: 280px; }
+
+    .quick-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .quick-actions .quick-btn {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      border: 1px dashed var(--line);
+      border-radius: 12px;
+      padding: 10px;
+      cursor: pointer;
+      text-align: center;
+      transition: all .2s ease;
+      background: var(--surface);
+    }
+
+    .quick-actions .quick-btn:hover {
+      border-style: solid;
+      border-color: var(--blue);
+      background: #eff6ff;
+    }
+
+    .heat-day {
+      width: 22px;
+      height: 22px;
+      border-radius: 4px;
+      display: grid;
+      place-items: center;
+      font-size: 10px;
+    }
+
+    .heat-legend {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+      font-size: 12px;
+      color: #64748b;
+    }
+
+    .editor-section {
+      border: 1px dashed var(--line);
+      border-radius: 12px;
+      padding: 12px;
+      margin-top: 10px;
+      background: var(--surface);
+    }
+
+    .qa-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    @media (max-width: 900px) {
+      .qa-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    .split-box {
+      border: 1px dashed var(--line);
+      padding: 8px;
+      border-radius: 10px;
+      background: var(--surface);
+    }
+
+    .banner {
+      background: #ecfeff;
+      border: 1px solid #cffafe;
+      border-radius: 12px;
+      padding: 10px;
+    }
+
+    .hint { font-size: 12px; color: #64748b; }
+
     .timeline-wrapper { position: relative; padding-top: 40px; margin-top: 16px; }
-    .timeline-labels { position: relative; height: 30px; margin-bottom: 5px;}
+    .timeline-labels { position: relative; height: 30px; margin-bottom: 5px; }
     .timeline-label { position: absolute; bottom: 0; transform: translateX(-50%); background: var(--bg); border: 1px solid var(--line); font-size: 11px; padding: 2px 6px; border-radius: 6px; white-space: nowrap; }
     .timeline-label::after { content: ''; position: absolute; bottom: -5px; left: 50%; transform: translateX(-50%); width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 5px solid var(--line); }
     .timeline-axis { display: flex; justify-content: space-between; font-size: 10px; color: var(--muted); border-top: 1px solid var(--line); padding-top: 4px; }
     .timeline-goals { position: relative; margin-top: 10px; }
-    .timeline-bar { position: absolute; height: 24px; background: linear-gradient(90deg, var(--blue) 0%, var(--blue) 100%); border-radius: 6px; overflow: hidden; display:flex; align-items:center; justify-content:space-between; padding: 0 8px; color:white; font-size:12px; white-space:nowrap; }
+    .timeline-bar { position: absolute; height: 24px; background: linear-gradient(90deg, var(--blue) 0%, var(--blue) 100%); border-radius: 6px; overflow: hidden; display: flex; align-items: center; justify-content: space-between; padding: 0 8px; color: white; font-size: 12px; white-space: nowrap; }
     .timeline-bar .bar-label { font-weight: 500; }
     .timeline-bar .bar-progress { opacity: 0.7; }
+
     .analytics-cat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
-    .analytics-filter-card{margin-top:12px;padding:16px;border-radius:16px;border:1px solid var(--line);background:var(--card);box-shadow:0 1px 2px rgba(15,23,42,0.08)}
-    .analytics-filter-grid{margin-top:12px;display:grid;gap:8px;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));max-height:260px;overflow-y:auto;padding-right:4px}
-    .analytics-filter-grid label{display:flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:10px;background:#fff;font-size:13px;cursor:pointer;transition:all .2s ease}
-    .analytics-filter-grid label.active{border-color:var(--blue);background:#eff6ff}
-    .analytics-filter-grid label span{flex:1;display:flex;align-items:center;gap:6px}
-    .analytics-filter-grid input{width:auto}
-    .analytics-filter-actions{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
-    .analytics-filter-actions .btn{padding:6px 10px;font-size:13px}
-    .analytics-summary{font-size:12px;color:var(--muted);margin-top:4px}
-    .analytics-month-picker{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
-    .analytics-month-chip{padding:6px 10px;border-radius:10px;border:1px solid var(--line);background:#fff;cursor:pointer;font-size:12px;transition:all .2s ease}
-    .analytics-month-chip.active{background:#0f172a;color:#fff;border-color:#0f172a}
-    .analytics-month-chip:hover{border-color:var(--blue)}
-    .table-sortable th{position:relative;white-space:nowrap}
-    .table-sortable th[data-sort]{cursor:pointer}
-    .table-sortable th .sort-indicator{font-size:10px;margin-left:4px;color:var(--muted)}
-    .table-sortable th.sorted-asc,.table-sortable th.sorted-desc{color:#0f172a}
-    .table-sortable th.sorted-asc .sort-indicator,.table-sortable th.sorted-desc .sort-indicator{color:#0f172a}
-    .th-label{display:inline-flex;align-items:center;gap:4px}
-    .inventory-table thead th,.inventory-table tbody td{padding:6px 8px;font-size:12px;line-height:1.3}
-    .inventory-table tbody td:first-child b{font-size:13px}
-    .inventory-table tbody td .muted{font-size:11px}
-    .inventory-table-actions .btn{padding:6px 10px;font-size:12px;border-radius:10px}
-    .inventory-plan-cell{min-width:200px}
-    .inventory-plan-input{width:100%;padding:6px 8px;border:1px solid var(--line);border-radius:8px;font-size:12px;background:#fff;min-width:0}
-    .inventory-plan-summary{margin-top:4px;font-size:11px;line-height:1.4;display:flex;flex-direction:column;gap:2px}
-    .delta-up{color:var(--green);font-weight:600}
-    .delta-down{color:var(--red);font-weight:600}
-    .delta-neutral{color:var(--muted);font-weight:500}
-    .chart-box.tall{height:320px}
-    .chart-box.wide{height:280px}
-    .insight-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;border:1px solid var(--line);font-size:12px;background:#f8fafc;margin-right:6px;margin-top:4px}
-    .insight-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
-    .eom-panel{background:#f8fafc;border:1px solid var(--line);border-radius:14px;padding:16px}
-    .eom-panel .title{font-size:18px;margin:0 0 6px 0}
-    .table-modern thead th{background:#f1f5f9;font-weight:600;font-size:13px;color:#475569;border-bottom:1px solid var(--line)}
-    .table-modern tbody tr:nth-child(even){background:#f8fafc}
-    .table-modern td{vertical-align:top}
-    .kpi-card{background:#0f172a;color:#fff;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:6px;min-height:120px}
-    .kpi-card.light{background:#f8fafc;color:#0f172a;border:1px solid var(--line)}
-    .kpi-card .label{font-size:12px;text-transform:uppercase;letter-spacing:0.08em;opacity:0.7}
-    .kpi-card .value{font-size:26px;font-weight:700}
-    .kpi-card .sub{font-size:12px;opacity:0.8}
-    .kpi-trend{font-size:12px;font-weight:600}
-    .kpi-trend.trend-up{color:var(--green)}
-    .kpi-trend.trend-down{color:var(--red)}
-    .kpi-trend.trend-flat{color:var(--muted)}
-    .inventory-toolbar{display:flex;flex-wrap:wrap;gap:12px;justify-content:space-between;align-items:flex-start;margin-top:16px}
-    .inventory-toolbar .row{gap:8px;flex-wrap:wrap}
-    .inventory-kpis{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;margin-top:12px}
-    .inventory-section{margin-top:16px}
-    .inventory-import{margin-top:16px}
-    .inventory-import textarea{width:100%;min-height:120px;border-radius:12px;border:1px dashed var(--line);padding:10px;font-family:inherit}
-    .inventory-inline{margin-top:8px;background:#f8fafc;border:1px dashed var(--line);border-radius:12px;padding:12px}
-    .inventory-inline .grid{grid-template-columns:repeat(auto-fit,minmax(160px,1fr))}
-    .inventory-empty{text-align:center;padding:16px;color:var(--muted);font-size:13px}
-    .inventory-table-actions{display:flex;flex-wrap:wrap;gap:6px}
-    .inventory-badge{display:inline-flex;align-items:center;gap:4px;background:#e2e8f0;border-radius:999px;padding:2px 8px;font-size:11px;color:#475569}
-    .inventory-quick-note{font-size:12px;color:var(--muted);margin-top:4px}
-    .chart-box{position:relative}
-    .chart-empty{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:13px;color:var(--muted)}
+
+    .analytics-filter-card {
+      margin-top: 12px;
+      padding: 16px;
+      border-radius: 16px;
+      border: 1px solid var(--line);
+      background: var(--card);
+      box-shadow: 0 1px 2px rgb(15 23 42 / 0.08);
+    }
+
+    .analytics-filter-grid {
+      margin-top: 12px;
+      display: grid;
+      gap: 8px;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      max-height: 260px;
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+
+    .analytics-filter-grid label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: #fff;
+      font-size: 13px;
+      cursor: pointer;
+      transition: all .2s ease;
+    }
+
+    .analytics-filter-grid label.active {
+      border-color: var(--blue);
+      background: #eff6ff;
+    }
+
+    .analytics-filter-grid label span {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .analytics-filter-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+    .analytics-summary { font-size: 12px; color: var(--muted); margin-top: 4px; }
+
+    .analytics-month-picker { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+    .analytics-month-chip { padding: 6px 10px; border-radius: 10px; border: 1px solid var(--line); background: #fff; cursor: pointer; font-size: 12px; transition: all .2s ease; }
+    .analytics-month-chip.active { background: #0f172a; color: #fff; border-color: #0f172a; }
+    .analytics-month-chip:hover { border-color: var(--blue); }
+
+    .table-sortable th { position: relative; white-space: nowrap; }
+    .table-sortable th[data-sort] { cursor: pointer; }
+    .table-sortable th .sort-indicator { font-size: 10px; margin-left: 4px; color: var(--muted); }
+
+    .th-label { display: inline-flex; align-items: center; gap: 4px; }
+
+    .inventory-table thead th,
+    .inventory-table tbody td {
+      padding: 6px 8px;
+      font-size: 12px;
+      line-height: 1.3;
+    }
+
+    .inventory-table tbody td:first-child b { font-size: 13px; }
+    .inventory-table tbody td .muted { font-size: 11px; }
+
+    .inventory-table-actions .btn { padding: 6px 10px; font-size: 12px; border-radius: 10px; }
+
+    .inventory-plan-cell { min-width: 200px; }
+    .inventory-plan-input { width: 100%; padding: 6px 8px; border: 1px solid var(--line); border-radius: 8px; font-size: 12px; background: #fff; min-width: 0; }
+    .inventory-plan-summary { margin-top: 4px; font-size: 11px; line-height: 1.4; display: flex; flex-direction: column; gap: 2px; }
+
+    .delta-up { color: var(--green); font-weight: 600; }
+    .delta-down { color: var(--red); font-weight: 600; }
+    .delta-neutral { color: var(--muted); font-weight: 500; }
+
+    .insight-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      font-size: 12px;
+      background: var(--surface);
+      margin-right: 6px;
+      margin-top: 4px;
+    }
+
+    .insight-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+
+    .eom-panel {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      padding: 16px;
+    }
+
+    .eom-panel .title { font-size: 18px; margin: 0 0 6px 0; }
+
+    .table-modern thead th {
+      background: #f1f5f9;
+      font-weight: 600;
+      font-size: 13px;
+      color: #475569;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .table-modern tbody tr:nth-child(even) { background: #f8fafc; }
+    .table-modern td { vertical-align: top; }
+
+    .kpi-card {
+      background: #0f172a;
+      color: #fff;
+      border-radius: 14px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-height: 120px;
+    }
+
+    .kpi-card.light {
+      background: var(--surface);
+      color: var(--ink);
+      border: 1px solid var(--line);
+    }
+
+    .kpi-card .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; opacity: 0.7; }
+    .kpi-card .value { font-size: 26px; font-weight: 700; }
+    .kpi-card .sub { font-size: 12px; opacity: 0.8; }
+
+    .kpi-trend { font-size: 12px; font-weight: 600; }
+    .kpi-trend.trend-up { color: var(--green); }
+    .kpi-trend.trend-down { color: var(--red); }
+    .kpi-trend.trend-flat { color: var(--muted); }
+
+    .inventory-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-top: 16px;
+    }
+
+    .inventory-toolbar .row { gap: 8px; flex-wrap: wrap; }
+
+    .inventory-kpis { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-top: 12px; }
+    .inventory-section { margin-top: 16px; }
+    .inventory-import { margin-top: 16px; }
+    .inventory-import textarea { width: 100%; min-height: 120px; border-radius: 12px; border: 1px dashed var(--line); padding: 10px; font-family: inherit; }
+    .inventory-inline { margin-top: 8px; background: var(--surface); border: 1px dashed var(--line); border-radius: 12px; padding: 12px; }
+    .inventory-inline .grid { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    .inventory-empty { text-align: center; padding: 16px; color: var(--muted); font-size: 13px; }
+    .inventory-table-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+    .inventory-badge { display: inline-flex; align-items: center; gap: 4px; background: #e2e8f0; border-radius: 999px; padding: 2px 8px; font-size: 11px; color: #475569; }
+    .inventory-quick-note { font-size: 12px; color: var(--muted); margin-top: 4px; }
+
+    .chart-empty {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 13px;
+      color: var(--muted);
+    }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <div class="row">
-      <div class="row" style="gap:10px">
-        <a href="./index.html" class="btn soft" style="text-decoration: none;">← Powrót</a>
-        <div>
-          <div style="font-weight:800">Mój Budżet</div>
-          <div class="muted" style="font-size:12px">Wersja lokalna</div>
+<body class="module-shell">
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Budżet</div>
+            <h1 class="module-title">Mój Budżet</h1>
+            <p class="module-subtitle">Wersja lokalna</p>
+          </div>
+        </div>
+        <div class="module-hero-actions">
+          <div class="toolbar budget-month-nav">
+            <button class="btn soft" id="prevMonthBtn" title="Poprzedni miesiąc">←</button>
+            <span class="pill" id="workingMonth">YYYY-MM</span>
+            <button class="btn soft" id="nextMonthBtn" title="Następny miesiąc">→</button>
+          </div>
+          <div class="toolbar budget-io-actions">
+            <button class="btn ghost" id="exportBtn">⬇️ Eksport JSON</button>
+            <button class="btn ghost" id="importBtn">⬆️ Import JSON</button>
+            <input type="file" id="importFile" accept="application/json" style="display:none" />
+          </div>
         </div>
       </div>
-      <div class="row" style="gap:8px">
-        <button class="btn soft" id="prevMonthBtn">←</button>
-        <span class="pill" id="workingMonth">YYYY-MM</span>
-        <button class="btn soft" id="nextMonthBtn">→</button>
-        <button class="btn ghost" id="exportBtn">⬇️ Eksport JSON</button>
-        <button class="btn ghost" id="importBtn">⬆️ Import JSON</button>
-        <input type="file" id="importFile" accept="application/json" style="display:none" />
+      <div class="module-hero-stats">
+        <div class="module-hero-stat neutral">
+          <span class="emoji">💸</span>
+          <div class="stat-body">
+            <span class="label">Zostało do wydania</span>
+            <span class="value big-number" id="dash-remaining">0</span>
+            <span class="note muted">na wydatki zmienne</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral">
+          <span class="emoji">📆</span>
+          <div class="stat-body">
+            <span class="label">Dzienny limit</span>
+            <span class="value big-number" id="dash-daily-budget">0</span>
+            <span class="note" id="dash-daily-trend">—</span>
+          </div>
+        </div>
+        <div class="module-hero-stat negative" id="dash-today-chip">
+          <span class="emoji">🔥</span>
+          <div class="stat-body">
+            <span class="label">Wydano dzisiaj</span>
+            <span class="value big-number" id="dash-today-spent">0</span>
+            <span class="note" id="dash-today-vs-budget">—</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral" id="dash-avg-chip">
+          <span class="emoji">📊</span>
+          <div class="stat-body">
+            <span class="label">Średnia dzienna</span>
+            <span class="value big-number" id="dash-avg-daily">0</span>
+            <span class="note" id="dash-avg-trend">—</span>
+          </div>
+        </div>
       </div>
     </div>
+  </section>
 
-    <div class="tabs" style="margin-top:12px">
+  <main class="module-content">
+    <div class="wrap">
+    <div class="tabs budget-tabs" style="margin-top:12px">
       <button class="tab active" data-tab="dashboard">Dashboard</button>
       <button class="tab" data-tab="overview">Przegląd</button>
       <button class="tab" data-tab="incomes">Przychody</button>
@@ -163,13 +393,6 @@
     <!-- Dashboard -->
     <section id="tab-dashboard" class="card" style="margin-top:12px">
       <h3 class="title">Dashboard finansowy</h3>
-      <div class="grid g-4">
-        <div class="stat-card"><div class="muted">Zostało do wydania</div><div class="big-number" id="dash-remaining">0</div><div class="muted">na wydatki zmienne</div></div>
-        <div class="stat-card"><div class="muted">Dzienny limit</div><div class="big-number" id="dash-daily-budget">0</div><div class="trend" id="dash-daily-trend"></div></div>
-        <div class="stat-card"><div class="muted">Wydano dzisiaj</div><div class="big-number" id="dash-today-spent">0</div><div class="trend" id="dash-today-vs-budget"></div></div>
-        <div class="stat-card"><div class="muted">Średnia dzienna</div><div class="big-number" id="dash-avg-daily">0</div><div class="trend" id="dash-avg-trend"></div></div>
-      </div>
-
       <div class="grid g-2" style="margin-top:12px">
         <div class="card">
           <div class="title">Wydatki dzień po dniu</div>
@@ -862,6 +1085,7 @@
       </div>
     </section>
   </div>
+  </main>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>

--- a/fuel.html
+++ b/fuel.html
@@ -4,123 +4,225 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Paliwo</title>
+  <link rel="stylesheet" href="assets/styles.css">
   <style>
-    :root{
-      --bg:#f8fafc;--card:#fff;--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;
-      --green:#059669;--red:#be123c;--orange:#ea580c;--blue:#0369a1
+    .fuel-insights-grid {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
-    *{box-sizing:border-box}
-    body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto}
-    .wrap{max-width:900px;margin:0 auto;padding:24px}
-    .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.03)}
-    .row{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
-    .muted{color:var(--muted)}
-    .title{margin:0 0 8px 0;font-weight:700}
-    .btn{display:inline-flex;gap:8px;align-items:center;border-radius:12px;padding:8px 12px;border:1px solid #0f172a;background:#0f172a;color:#fff;cursor:pointer; text-decoration: none;}
-    .btn.soft{background:#f1f5f9;border-color:#e2e8f0;color:#0f172a}
-    .btn.danger{background:#ffe4e6;border-color:#fecdd3;color:#b91c1c}
-    input,select{border:1px solid var(--line);border-radius:10px;padding:8px;background:#fff;color:#0f172a;width:100%}
-    .grid{display:grid;gap:16px}
-    .g-2{grid-template-columns:repeat(2,minmax(0,1fr))}
-    @media(max-width:900px){.g-2{grid-template-columns:1fr}}
-    .g-4{grid-template-columns:repeat(4,minmax(0,1fr))}
-    @media(max-width:900px){.g-4{grid-template-columns:1fr 1fr}}
-    .ok{color:var(--green)}.bad{color:var(--red)}
-    .stat-card{background:#f8fafc;border:1px solid var(--line);border-radius:12px;padding:12px; text-align: center;}
-    .big-number{font-weight:800;font-size:32px}
-    table{width:100%;border-collapse:collapse}
-    th,td{padding:8px;border-top:1px solid var(--line);text-align:left;vertical-align:middle}
-    .chart-box{height:240px; margin-top: 16px;}
+
+    .insight-card {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .insight-card .label {
+      font-size: 12px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 600;
+    }
+
+    .insight-card .value {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .insight-card .note {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .fuel-form-grid {
+      align-items: flex-end;
+    }
+
+    .fuel-form-actions {
+      grid-column: 1 / -1;
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .fuel-analytics-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .summary-delta {
+      font-weight: 600;
+    }
+
+    .summary-delta.up {
+      color: var(--red);
+    }
+
+    .summary-delta.down {
+      color: var(--green);
+    }
+
+    .summary-delta.flat {
+      color: var(--muted);
+    }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <div class="row">
-      <div class="row" style="gap:10px">
-        <a href="./index.html" class="btn soft" style="text-decoration: none;">← Powrót</a>
-        <div>
-          <div style="font-weight:800">Moduł Paliwowy</div>
-          <div class="muted" style="font-size:12px">Rozliczenia z firmą</div>
+<body class="module-shell">
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Finanse</div>
+            <h1 class="module-title">Moduł paliwowy</h1>
+            <p class="module-subtitle">Rozliczaj wydatki służbowe i prywatne tankowania w jednym miejscu.</p>
+          </div>
+        </div>
+        <div class="module-hero-actions">
+          <button id="import-csv-btn" class="btn soft">Importuj z CSV</button>
+          <input type="file" id="csv-file-input" accept=".csv" style="display:none;">
+          <button id="export-csv-btn" class="btn soft">Eksportuj do CSV</button>
+          <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
         </div>
       </div>
-      <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
-    </div>
-
-    <div class="grid g-2" style="margin-top:16px;">
-        <div class="stat-card">
-            <div class="muted">Aktualne Saldo</div>
-            <div id="fuel-balance" class="big-number">0,00 PLN</div>
-            <div class="muted" id="balance-info"></div>
+      <div class="module-hero-stats" id="fuel-hero-glance">
+        <div class="module-hero-stat neutral">
+          <span class="emoji">⛽</span>
+          <div class="stat-body">
+            <span class="label">Śr. cena (12 mies.)</span>
+            <span class="value" id="fuel-avg-price">—</span>
+            <span class="note" id="fuel-avg-price-note">Brak danych</span>
+          </div>
         </div>
-        <div id="last-invoice-card" class="stat-card"></div>
-    </div>
-
-    <div class="card" style="margin-top:16px;">
-        <h3 class="title" id="form-title">Dodaj Transakcję</h3>
-        <div class="grid g-4">
-            <input type="hidden" id="tx-id">
-            <input type="date" id="tx-date">
-            <select id="tx-type">
-                <option value="invoice">Faktura (koszt)</option>
-                <option value="advance">Zaliczka (wpływ)</option>
-            </select>
-            <input type="text" id="tx-ref" placeholder="Nr faktury / Opis">
-            <input type="text" id="tx-liters" placeholder="Litry (opcjonalnie)" inputmode="decimal">
-            <input type="text" id="tx-amount" placeholder="Kwota" inputmode="decimal" required>
-            <div style="grid-column: 1 / -1; display:flex; gap: 8px; justify-content:flex-end;">
-              <button id="cancel-edit-btn" class="btn soft" style="display:none;">Anuluj</button>
-              <button id="add-tx-btn" class="btn">Dodaj</button>
-            </div>
+        <div class="module-hero-stat positive" id="fuel-balance-chip">
+          <span class="emoji">💼</span>
+          <div class="stat-body">
+            <span class="label">Saldo zaliczki</span>
+            <span class="value" id="fuel-balance-value">0,00 PLN</span>
+            <span class="note" id="balance-info">—</span>
+          </div>
         </div>
+        <div class="module-hero-stat neutral" id="fuel-last-invoice-chip">
+          <span class="emoji">🧾</span>
+          <div class="stat-body">
+            <span class="label">Ostatnia faktura</span>
+            <span class="value" id="fuel-last-invoice-value">—</span>
+            <span class="note" id="fuel-last-invoice-note">Brak faktur w historii</span>
+          </div>
+        </div>
+      </div>
     </div>
-    
-    <div class="card" style="margin-top:16px;">
-        <div class="row">
-          <h3 class="title">Analityka</h3>
-          <select id="analytics-period-filter" style="width:auto;">
-              <option value="12" selected>Ostatni rok</option>
-              <option value="24">Ostatnie 2 lata</option>
-              <option value="36">Ostatnie 3 lata</option>
-              <option value="all">Wszystkie dane</option>
+  </section>
+
+  <main class="module-content">
+    <div class="wrap">
+      <section class="card card-section">
+        <div class="section-heading">
+          <h2 class="title" id="form-title">Dodaj transakcję</h2>
+          <span class="tiny muted">Obsługujemy faktury i zaliczki firmowe</span>
+        </div>
+        <div class="grid g-4 fuel-form-grid">
+          <input type="hidden" id="tx-id">
+          <input type="date" id="tx-date">
+          <select id="tx-type">
+            <option value="invoice">Faktura (koszt)</option>
+            <option value="advance">Zaliczka (wpływ)</option>
           </select>
+          <input type="text" id="tx-ref" placeholder="Nr faktury / Opis">
+          <input type="text" id="tx-liters" placeholder="Litry (opcjonalnie)" inputmode="decimal">
+          <input type="text" id="tx-amount" placeholder="Kwota" inputmode="decimal" required>
+          <div class="fuel-form-actions">
+            <button id="cancel-edit-btn" class="btn soft" style="display:none;">Anuluj</button>
+            <button id="add-tx-btn" class="btn primary">Dodaj</button>
+          </div>
         </div>
-        <div class="grid" style="margin-top:12px;">
-            <div class="card">
-                <div class="title">Miesięczne Koszty i Liczba Tankowań</div>
-                <div class="chart-box"><canvas id="monthly-costs-chart"></canvas></div>
-            </div>
-            <div class="card">
-                <div class="title">Średnia Cena za Litr</div>
-                <div class="chart-box"><canvas id="avg-price-chart"></canvas></div>
-            </div>
-        </div>
-    </div>
+      </section>
 
-    <div class="card" style="margin-top:16px;">
-        <div class="row">
-            <h3 class="title">Historia Transakcji</h3>
-            <div style="display:flex; gap: 8px;">
-                <button id="import-csv-btn" class="btn soft">Importuj z CSV</button>
-                <input type="file" id="csv-file-input" accept=".csv" style="display:none;">
-                <button id="export-csv-btn" class="btn soft">Eksportuj do CSV</button>
-            </div>
+      <section class="card card-section">
+        <div class="section-heading">
+          <h2 class="title">Historia transakcji</h2>
+          <span class="tiny muted">Kliknij wpis, aby edytować lub usuń w przypadku pomyłki</span>
         </div>
-        <table>
+        <div class="table-wrapper">
+          <table>
             <thead>
-                <tr>
-                    <th>Data</th>
-                    <th>Typ</th>
-                    <th>Opis/Nr faktury</th>
-                    <th>Litry</th>
-                    <th>Cena/l</th>
-                    <th>Kwota</th>
-                    <th></th>
-                </tr>
+              <tr>
+                <th>Data</th>
+                <th>Typ</th>
+                <th>Opis/Nr faktury</th>
+                <th>Litry</th>
+                <th>Cena/l</th>
+                <th>Kwota</th>
+                <th>Akcje</th>
+              </tr>
             </thead>
             <tbody id="history-tbody"></tbody>
-        </table>
+          </table>
+        </div>
+      </section>
+
+      <section class="card card-section">
+        <div class="section-heading">
+          <h2 class="title">Kluczowe wnioski</h2>
+          <span class="tiny muted">Aktualizowane automatycznie na podstawie historii tankowań</span>
+        </div>
+        <div id="insights-grid" class="fuel-insights-grid"></div>
+      </section>
+
+      <section class="card card-section">
+        <div class="section-heading">
+          <h2 class="title">Podsumowanie miesięczne</h2>
+          <p class="tiny muted" id="monthly-summary-caption">Ostatnie 6 miesięcy</p>
+        </div>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Miesiąc</th>
+                <th>Faktury</th>
+                <th>Litry</th>
+                <th>Śr. cena</th>
+                <th>Zmiana m/m</th>
+              </tr>
+            </thead>
+            <tbody id="monthly-summary-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card card-section">
+        <div class="section-heading">
+          <h2 class="title">Analityka</h2>
+          <select id="analytics-period-filter" style="width:auto;">
+            <option value="12" selected>Ostatni rok</option>
+            <option value="24">Ostatnie 2 lata</option>
+            <option value="36">Ostatnie 3 lata</option>
+            <option value="all">Wszystkie dane</option>
+          </select>
+        </div>
+        <div class="fuel-analytics-grid">
+          <article class="chart-card">
+            <h3 class="title">Miesięczne koszty i liczba tankowań</h3>
+            <div class="chart-area"><canvas id="monthly-costs-chart"></canvas></div>
+          </article>
+          <article class="chart-card">
+            <h3 class="title">Średnia cena za litr</h3>
+            <div class="chart-area"><canvas id="avg-price-chart"></canvas></div>
+          </article>
+        </div>
+      </section>
     </div>
-  </div>
+  </main>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
@@ -150,9 +252,42 @@ function num(s){
     return Number.isFinite(n) ? n : 0;
 }
 
+function normalizeTransactions(list){
+    if(!Array.isArray(list)) return [];
+    return list.map(tx => {
+        if(!tx) return null;
+        const normalized = { ...tx };
+        const rawAmount = num(tx.amount ?? tx.value);
+        let type = (tx.type || '').toLowerCase();
+        if(type !== 'invoice' && type !== 'advance') {
+            type = rawAmount >= 0 ? 'advance' : 'invoice';
+        }
+        normalized.type = type;
+        normalized.amount = type === 'invoice' ? -Math.abs(rawAmount) : Math.abs(rawAmount);
+        const litersSource = tx.liters ?? tx.details?.liters ?? tx.volume;
+        const litersValue = num(litersSource);
+        normalized.liters = type === 'invoice' && litersValue > 0 ? litersValue : null;
+        if(!normalized.ref && tx.reference) normalized.ref = tx.reference;
+        if(!normalized.id){
+            const seed = `${tx.date || Date.now()}_${Math.random().toString(16).slice(2,8)}`;
+            normalized.id = `tx_${seed}`;
+        }
+        return normalized;
+    }).filter(Boolean);
+}
+
 function loadState(){
-    const raw = localStorage.getItem(FUEL_STORAGE_KEY);
-    if(raw) return JSON.parse(raw);
+    try {
+        const raw = localStorage.getItem(FUEL_STORAGE_KEY);
+        if(!raw) return { transactions: [] };
+        const parsed = JSON.parse(raw);
+        if(parsed && typeof parsed === 'object'){
+            const transactions = Array.isArray(parsed.transactions) ? parsed.transactions : [];
+            return { ...parsed, transactions: normalizeTransactions(transactions) };
+        }
+    } catch {
+        return { transactions: [] };
+    }
     return { transactions: [] };
 }
 
@@ -171,6 +306,77 @@ function updateKPIs(state) {
 
 let state = loadState();
 
+function computeFuelMetrics(transactions = []) {
+    const list = Array.isArray(transactions) ? [...transactions] : [];
+    const invoices = list.filter(tx => tx.type === 'invoice' && tx.date);
+    const advances = list.filter(tx => tx.type === 'advance');
+    const totalBalance = list.reduce((acc, tx) => acc + (tx.amount || 0), 0);
+
+    const sortedInvoices = invoices.slice().sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+    const lastInvoice = sortedInvoices[0] || null;
+
+    const now = new Date();
+    const lastYearThreshold = new Date(now);
+    lastYearThreshold.setFullYear(lastYearThreshold.getFullYear() - 1);
+    const invoicesLastYear = sortedInvoices.filter(tx => {
+        if (!tx.date) return false;
+        const parsed = new Date(tx.date);
+        return !Number.isNaN(parsed.valueOf()) && parsed >= lastYearThreshold;
+    });
+    const costLastYear = invoicesLastYear.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+    const litersLastYear = invoicesLastYear.reduce((sum, tx) => sum + (tx.liters || 0), 0);
+    const avgPrice12m = litersLastYear > 0 ? costLastYear / litersLastYear : 0;
+    const avgInvoice12m = invoicesLastYear.length ? costLastYear / invoicesLastYear.length : 0;
+
+    const last30Threshold = new Date(now);
+    last30Threshold.setDate(last30Threshold.getDate() - 30);
+    const last30Invoices = sortedInvoices.filter(tx => {
+        if (!tx.date) return false;
+        const parsed = new Date(tx.date);
+        return !Number.isNaN(parsed.valueOf()) && parsed >= last30Threshold;
+    });
+    const last30Cost = last30Invoices.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+
+    const bestPriceInvoice = sortedInvoices.reduce((best, tx) => {
+        if (!tx.liters || !tx.amount) return best;
+        const unitPrice = Math.abs(tx.amount) / tx.liters;
+        if (!best || unitPrice < best.unitPrice) {
+            return { unitPrice, ref: tx.ref, date: tx.date };
+        }
+        return best;
+    }, null);
+
+    const worstPriceInvoice = sortedInvoices.reduce((worst, tx) => {
+        if (!tx.liters || !tx.amount) return worst;
+        const unitPrice = Math.abs(tx.amount) / tx.liters;
+        if (!worst || unitPrice > worst.unitPrice) {
+            return { unitPrice, ref: tx.ref, date: tx.date };
+        }
+        return worst;
+    }, null);
+
+    const advancesValue = advances.reduce((sum, tx) => sum + (tx.amount || 0), 0);
+
+    return {
+        invoices: sortedInvoices,
+        advances,
+        advancesValue,
+        totalBalance,
+        lastInvoice,
+        invoicesLastYear,
+        costLastYear,
+        litersLastYear,
+        avgPrice12m,
+        avgInvoice12m,
+        last30Invoices,
+        last30Cost,
+        bestPriceInvoice,
+        worstPriceInvoice,
+    };
+}
+
+let latestMetrics = computeFuelMetrics(state.transactions);
+
 const formTitle = document.getElementById('form-title');
 const txIdInput = document.getElementById('tx-id');
 const dateInput = document.getElementById('tx-date');
@@ -181,9 +387,13 @@ const amountInput = document.getElementById('tx-amount');
 const addBtn = document.getElementById('add-tx-btn');
 const cancelEditBtn = document.getElementById('cancel-edit-btn');
 const historyTbody = document.getElementById('history-tbody');
-const balanceEl = document.getElementById('fuel-balance');
+const balanceChip = document.getElementById('fuel-balance-chip');
+const balanceValueEl = document.getElementById('fuel-balance-value');
 const balanceInfoEl = document.getElementById('balance-info');
-const lastInvoiceCard = document.getElementById('last-invoice-card');
+const avgPriceEl = document.getElementById('fuel-avg-price');
+const avgPriceNoteEl = document.getElementById('fuel-avg-price-note');
+const lastInvoiceValueEl = document.getElementById('fuel-last-invoice-value');
+const lastInvoiceNoteEl = document.getElementById('fuel-last-invoice-note');
 const exportBtn = document.getElementById('export-csv-btn');
 const importBtn = document.getElementById('import-csv-btn');
 const csvFileInput = document.getElementById('csv-file-input');
@@ -191,25 +401,50 @@ const clearAllBtn = document.getElementById('clear-all-btn');
 
 
 function render() {
-    state.transactions.sort((a,b) => b.date.localeCompare(a.date));
-    
-    // Render Balance and Last Invoice
-    const totalBalance = state.transactions.reduce((acc, tx) => acc + tx.amount, 0);
-    balanceEl.textContent = fmt(totalBalance);
-    balanceEl.className = `big-number ${totalBalance >= 0 ? 'ok' : 'bad'}`;
-    balanceInfoEl.textContent = totalBalance >= 0 ? 'Firma jest Ci winna pieniądze' : 'Musisz zwrócić pieniądze firmie';
-    
-    const lastInvoice = state.transactions.find(tx => tx.type === 'invoice');
-    if (lastInvoice) {
-        const daysSince = Math.floor((new Date() - new Date(lastInvoice.date)) / (1000 * 60 * 60 * 24));
-        const pricePerLiter = (lastInvoice.liters) ? Math.abs(lastInvoice.amount / lastInvoice.liters) : 0;
-        lastInvoiceCard.innerHTML = `
-            <div class="muted">Ostatnia faktura (${daysSince} dni temu)</div>
-            <div style="font-size:18px; font-weight: 600;">${lastInvoice.date}</div>
-            <div class="muted">${fmt(Math.abs(lastInvoice.amount))} • ${lastInvoice.liters || 'N/A'} L • ${fmt(pricePerLiter, 'PLN/L')}</div>
-        `;
+    state.transactions = normalizeTransactions(state.transactions || []);
+    state.transactions.sort((a,b) => (b.date || '').localeCompare(a.date || ''));
+
+    latestMetrics = computeFuelMetrics(state.transactions);
+
+    // Render hero metrics
+    const balance = latestMetrics.totalBalance;
+    balanceValueEl.textContent = fmt(balance);
+    balanceChip.classList.remove('positive', 'negative', 'neutral');
+    if (balance > 0) {
+        balanceChip.classList.add('positive');
+        balanceInfoEl.textContent = 'Masz jeszcze środki z zaliczki do wykorzystania';
+    } else if (balance < 0) {
+        balanceChip.classList.add('negative');
+        balanceInfoEl.textContent = 'Musisz rozliczyć nadwyżkę wobec firmy';
     } else {
-        lastInvoiceCard.innerHTML = `<div class="muted">Brak faktur w historii</div>`;
+        balanceChip.classList.add('neutral');
+        balanceInfoEl.textContent = 'Saldo rozliczeń jest na poziomie 0 PLN';
+    }
+
+    if (latestMetrics.avgPrice12m > 0) {
+        avgPriceEl.textContent = fmt(latestMetrics.avgPrice12m, 'PLN/L');
+        const litersLabel = latestMetrics.litersLastYear.toFixed(1).replace('.0', '');
+        avgPriceNoteEl.textContent = `${litersLabel} L w ${latestMetrics.invoicesLastYear.length} fakturach (12 mies.)`;
+    } else {
+        avgPriceEl.textContent = '—';
+        avgPriceNoteEl.textContent = 'Brak danych z ostatnich 12 miesięcy';
+    }
+
+    if (latestMetrics.lastInvoice) {
+        const lastInvoice = latestMetrics.lastInvoice;
+        const invoiceDate = new Date(lastInvoice.date);
+        const daysSince = Number.isNaN(invoiceDate.valueOf()) ? null : Math.floor((new Date() - invoiceDate) / (1000 * 60 * 60 * 24));
+        const litersValue = typeof lastInvoice.liters === 'number' ? lastInvoice.liters : num(lastInvoice.liters);
+        const pricePerLiter = litersValue ? Math.abs(lastInvoice.amount) / litersValue : 0;
+        lastInvoiceValueEl.textContent = fmt(Math.abs(lastInvoice.amount));
+        const dateLabel = lastInvoice.date || '—';
+        const litersLabel = litersValue ? `${litersValue.toFixed(2)} L` : '—';
+        const priceLabel = litersValue ? fmt(pricePerLiter, 'PLN/L') : '—';
+        const recency = typeof daysSince === 'number' ? `${daysSince} dni temu` : 'niedawno';
+        lastInvoiceNoteEl.textContent = `${dateLabel} • ${litersLabel} • ${priceLabel} (${recency})`;
+    } else {
+        lastInvoiceValueEl.textContent = '—';
+        lastInvoiceNoteEl.textContent = 'Brak faktur w historii';
     }
 
     // Render History Table
@@ -253,8 +488,123 @@ function render() {
         };
     });
 
-
+    renderInsightsSection();
+    renderMonthlySummary();
     renderAnalytics();
+}
+
+function renderInsightsSection() {
+    const grid = document.getElementById('insights-grid');
+    if (!grid) return;
+
+    if (!state.transactions.length) {
+        grid.innerHTML = '<p class="tiny muted">Dodaj pierwszą transakcję, aby zobaczyć kluczowe wskaźniki.</p>';
+        return;
+    }
+
+    const metrics = latestMetrics || computeFuelMetrics(state.transactions);
+    const advances = metrics.advances;
+    const avgPrice = metrics.avgPrice12m;
+    const avgInvoice = metrics.avgInvoice12m;
+    const last30Invoices = metrics.last30Invoices;
+    const last30Cost = metrics.last30Cost;
+    const bestPriceInvoice = metrics.bestPriceInvoice;
+    const worstPriceInvoice = metrics.worstPriceInvoice;
+    const litersLastYear = metrics.litersLastYear;
+    const invoicesLastYear = metrics.invoicesLastYear;
+    const advancesValue = metrics.advancesValue;
+    const balance = metrics.totalBalance;
+
+    const cards = [
+        {
+            label: '⛽ Średnia cena za litr',
+            value: litersLastYear > 0 ? fmt(avgPrice, 'PLN/L') : '—',
+            note: litersLastYear > 0 ? `${litersLastYear.toFixed(1)} L w ${invoicesLastYear.length} fakturach (12 mies.)` : 'Brak danych z ostatniego roku'
+        },
+        {
+            label: '🗓️ Koszt ostatnich 30 dni',
+            value: last30Invoices.length ? fmt(last30Cost) : '—',
+            note: last30Invoices.length ? `${last30Invoices.length} tankowania` : 'Brak nowych faktur'
+        },
+        {
+            label: '🥇 Najlepsza cena',
+            value: bestPriceInvoice ? fmt(bestPriceInvoice.unitPrice, 'PLN/L') : '—',
+            note: bestPriceInvoice ? `${bestPriceInvoice.ref || 'Faktura'} (${bestPriceInvoice.date})` : 'Brak danych o litrach'
+        },
+        {
+            label: '⚠️ Najwyższa cena',
+            value: worstPriceInvoice ? fmt(worstPriceInvoice.unitPrice, 'PLN/L') : '—',
+            note: worstPriceInvoice ? `${worstPriceInvoice.ref || 'Faktura'} (${worstPriceInvoice.date})` : 'Brak danych o litrach'
+        },
+        {
+            label: '💳 Śr. kwota faktury',
+            value: invoicesLastYear.length ? fmt(avgInvoice) : '—',
+            note: invoicesLastYear.length ? `${invoicesLastYear.length} faktur z ostatnich 12 miesięcy` : (advances.length ? `${advances.length} zaliczek na ${fmt(advancesValue)}` : 'Brak danych z ostatniego roku')
+        },
+        {
+            label: '💼 Saldo rozliczeń',
+            value: fmt(balance),
+            note: balance >= 0 ? 'Pozostałe środki z zaliczki' : 'Do zwrotu dla firmy'
+        }
+    ];
+
+    grid.innerHTML = cards.map(card => `
+        <div class="insight-card">
+            <div class="label">${card.label}</div>
+            <div class="value">${card.value}</div>
+            <div class="note">${card.note}</div>
+        </div>
+    `).join('');
+}
+
+function renderMonthlySummary() {
+    const tbody = document.getElementById('monthly-summary-body');
+    const caption = document.getElementById('monthly-summary-caption');
+    if (!tbody) return;
+
+    const invoices = state.transactions.filter(tx => tx.type === 'invoice' && tx.date);
+    if (!invoices.length) {
+        tbody.innerHTML = '<tr><td colspan="5" class="muted" style="text-align:center;">Brak danych do wyświetlenia.</td></tr>';
+        if (caption) caption.textContent = 'Brak danych miesięcznych';
+        return;
+    }
+
+    const monthly = {};
+    invoices.forEach(tx => {
+        const month = tx.date.slice(0, 7);
+        if (!monthly[month]) monthly[month] = { cost: 0, liters: 0, count: 0 };
+        monthly[month].cost += Math.abs(tx.amount);
+        monthly[month].liters += tx.liters || 0;
+        monthly[month].count += 1;
+    });
+
+    const months = Object.keys(monthly).sort();
+    const recentMonths = months.slice(-6);
+    if (caption) caption.textContent = recentMonths.length ? `Ostatnie ${recentMonths.length} miesięcy` : 'Brak danych miesięcznych';
+
+    tbody.innerHTML = recentMonths.map((month, index) => {
+        const data = monthly[month];
+        const avgPrice = data.liters > 0 ? data.cost / data.liters : 0;
+        const prevMonthKey = recentMonths[index - 1];
+        const prev = prevMonthKey ? monthly[prevMonthKey] : null;
+        let deltaCell = '—';
+        if (prev) {
+            const delta = data.cost - prev.cost;
+            const deltaClass = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
+            const symbol = delta > 0 ? '↑' : delta < 0 ? '↓' : '→';
+            deltaCell = `<span class="summary-delta ${deltaClass}">${symbol} ${fmt(Math.abs(delta))}</span>`;
+        }
+        const label = new Date(`${month}-01`).toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+        return `
+            <tr>
+                <td>${label}</td>
+                <td>${data.count}</td>
+                <td>${data.liters ? data.liters.toFixed(1) + ' L' : '—'}</td>
+                <td>${data.liters ? fmt(avgPrice, 'PLN/L') : '—'}</td>
+                <td>${deltaCell}</td>
+            </tr>
+        `;
+    }).join('');
 }
 
 function startEdit(id) {

--- a/house.html
+++ b/house.html
@@ -4,38 +4,39 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BuildMaster Pro — Centrum Zarządzania Budową</title>
+  <link rel="stylesheet" href="assets/styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     :root {
-      --primary: #3b82f6;
-      --primary-dark: #2563eb;
-      --primary-light: #dbeafe;
-      --primary-lighter: #eff6ff;
-      --success: #10b981;
-      --success-light: #d1fae5;
-      --error: #ef4444;
-      --error-light: #fee2e2;
-      --warning: #f59e0b;
-      --warning-light: #fef3c7;
-      --info: #6366f1;
-      --info-light: #e0e7ff;
-      --bg: #f8fafc;
-      --bg-secondary: #f1f5f9;
+      --primary: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
+      --primary-dark: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) - 10%));
+      --primary-light: hsl(var(--accent-h) 82% 90%);
+      --primary-lighter: hsl(var(--accent-h) 88% 96%);
+      --success: var(--green);
+      --success-light: var(--green-soft);
+      --error: var(--red);
+      --error-light: var(--red-soft);
+      --warning: var(--orange);
+      --warning-light: var(--orange-soft);
+      --info: hsl(var(--accent-h) 70% 60%);
+      --info-light: hsl(var(--accent-h) 80% 92%);
+      --bg: var(--surface);
+      --bg-secondary: hsl(var(--accent-h) 70% 96%);
       --sidebar-bg: #0f172a;
-      --card-bg: #ffffff;
-      --text-primary: #0f172a;
-      --text-secondary: #64748b;
-      --text-tertiary: #94a3b8;
-      --border: #e2e8f0;
-      --border-light: #f1f5f9;
-      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-      --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-      --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+      --card-bg: var(--card);
+      --text-primary: var(--ink);
+      --text-secondary: var(--muted);
+      --text-tertiary: hsl(var(--accent-h) 20% 65%);
+      --border: var(--line);
+      --border-light: hsl(var(--accent-h) 55% 90%);
+      --shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.05);
+      --shadow: 0 1px 3px 0 rgb(15 23 42 / 0.1), 0 1px 2px -1px rgb(15 23 42 / 0.08);
+      --shadow-md: 0 4px 10px -2px rgb(15 23 42 / 0.12);
+      --shadow-lg: 0 18px 35px -10px rgb(15 23 42 / 0.18);
+      --shadow-xl: 0 30px 60px -24px rgb(15 23 42 / 0.22);
       --radius: 12px;
       --radius-sm: 8px;
       --radius-lg: 16px;
@@ -44,9 +45,9 @@
     }
 
     [data-theme="dark"] {
-      --primary: #60a5fa;
-      --primary-dark: #3b82f6;
-      --primary-light: #1e3a8a;
+      --primary: hsl(var(--accent-h) 75% 70%);
+      --primary-dark: hsl(var(--accent-h) 70% 62%);
+      --primary-light: hsl(var(--accent-h) 60% 45%);
       --primary-lighter: #1e293b;
       --bg: #0f172a;
       --bg-secondary: #1e293b;
@@ -73,12 +74,10 @@
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       background: var(--bg);
       color: var(--text-primary);
-      display: flex;
-      height: 100vh;
-      overflow: hidden;
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.6;
       transition: var(--transition);
-      font-size: 15px;
-      line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
@@ -220,22 +219,61 @@
     }
     
     .nav-icon {
-      width: 20px;
-      height: 20px;
-      display: flex;
+      font-size: 16px;
+      line-height: 1;
+      display: inline-flex;
       align-items: center;
       justify-content: center;
-      flex-shrink: 0;
     }
-    
+
     .nav-badge {
-      margin-left: auto;
+      margin-left: 6px;
       background: var(--error);
-      color: white;
+      color: #fff;
       font-size: 11px;
       padding: 2px 6px;
-      border-radius: 10px;
+      border-radius: 999px;
       font-weight: 700;
+    }
+
+    .house-hero-actions {
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .house-tabs {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      padding-bottom: 8px;
+      gap: 8px;
+    }
+
+    .house-tabs::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    .house-tabs .page-tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .house-tabs .page-tab .nav-badge {
+      margin-left: auto;
+    }
+
+    .module-panels {
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+      padding-top: 24px;
+    }
+
+    .module-panels .tab-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
     }
 
     .sidebar-footer {
@@ -266,6 +304,10 @@
       align-items: center;
       gap: 24px;
     }
+
+    .topbar-left .back-link {
+      font-size: 13px;
+    }
     
     .page-title {
       font-size: 24px;
@@ -291,71 +333,68 @@
 
     /* Buttons */
     .btn {
-      padding: 10px 20px;
-      border: 2px solid var(--border);
-      background: var(--card-bg);
-      color: var(--text-primary);
-      border-radius: var(--radius-sm);
-      cursor: pointer;
-      font-weight: 600;
-      font-size: 14px;
-      transition: var(--transition);
       display: inline-flex;
       align-items: center;
       justify-content: center;
       gap: 8px;
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-primary);
+      font-weight: 600;
+      font-size: 13px;
+      cursor: pointer;
+      transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
       white-space: nowrap;
-      position: relative;
-      overflow: hidden;
     }
-    
+
     .btn:hover {
-      transform: translateY(-2px);
+      transform: translateY(-1px);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+      border-color: transparent;
+    }
+
+    .btn-primary:hover {
       box-shadow: var(--shadow-md);
     }
-    
-    .btn:active {
-      transform: translateY(0);
-    }
-    
-    .btn-primary {
-      background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-      color: white;
-      border: none;
-    }
-    
-    .btn-primary:hover {
-      box-shadow: 0 8px 16px rgba(59, 130, 246, 0.3);
-    }
-    
+
     .btn-success {
       background: var(--success);
-      color: white;
-      border: none;
+      color: #fff;
+      border-color: transparent;
     }
-    
+
     .btn-danger {
       background: var(--error);
-      color: white;
-      border: none;
+      color: #fff;
+      border-color: transparent;
     }
-    
+
     .btn-ghost {
       background: transparent;
-      border: none;
+      border-color: var(--border);
       color: var(--text-secondary);
     }
-    
+
     .btn-ghost:hover {
-      background: var(--bg-secondary);
+      background: var(--surface);
       color: var(--text-primary);
     }
-    
+
     .btn-icon {
       width: 40px;
       height: 40px;
       padding: 0;
-      border-radius: 50%;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      font-size: 18px;
     }
     
     .btn-group {
@@ -1901,113 +1940,80 @@
     }
   </style>
 </head>
-<body>
-  <!-- Sidebar -->
-  <aside class="sidebar" id="sidebar">
-    <div class="sidebar-header">
-      <div class="logo">
-        <div class="logo-icon">🏗️</div>
-        <div class="logo-text">
-          <h1>BuildMaster</h1>
-          <p>Centrum Zarządzania</p>
+<body class="module-shell">
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Dom i budowa</div>
+            <h1 class="module-title">BuildMaster Pro</h1>
+            <p class="module-subtitle">Monitoruj postęp projektu domu, kontroluj budżet i reaguj na zagrożenia w jednym miejscu.</p>
+          </div>
+        </div>
+        <div class="module-hero-actions house-hero-actions">
+          <button class="btn soft" type="button" onclick="exportData()">📥 Eksport</button>
+          <button class="btn soft" type="button" onclick="importData()">📤 Import</button>
+          <button class="btn soft" type="button" onclick="generateReport()">📋 Raport</button>
+          <button class="btn soft" type="button" onclick="openSettingsModal()">⚙️ Ustawienia</button>
+          <button class="btn ghost icon-btn" id="theme-toggle" type="button" onclick="toggleTheme()">🌙</button>
+        </div>
+      </div>
+      <div class="module-hero-stats">
+        <div class="module-hero-stat positive" id="hero-progress-chip">
+          <span class="emoji">🚧</span>
+          <div class="stat-body">
+            <span class="label">Postęp projektu</span>
+            <span class="value" id="hero-progress">0%</span>
+            <span class="note" id="hero-progress-note">Średnia ukończenia zadań</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral" id="hero-budget-chip">
+          <span class="emoji">💰</span>
+          <div class="stat-body">
+            <span class="label">Wydatki</span>
+            <span class="value" id="hero-budget">0 zł</span>
+            <span class="note" id="hero-budget-note">z planowanego budżetu</span>
+          </div>
+        </div>
+        <div class="module-hero-stat negative" id="hero-overdue-chip">
+          <span class="emoji">⏰</span>
+          <div class="stat-body">
+            <span class="label">Opóźnienia</span>
+            <span class="value" id="hero-overdue">0</span>
+            <span class="note" id="hero-overdue-note">Zadań po terminie</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral" id="hero-timeline-chip">
+          <span class="emoji">📅</span>
+          <div class="stat-body">
+            <span class="label">Do terminu</span>
+            <span class="value" id="hero-timeline">—</span>
+            <span class="note" id="hero-timeline-note">Brak planowanej daty zakończenia</span>
+          </div>
         </div>
       </div>
     </div>
+  </section>
 
-    <ul class="nav-menu" id="nav-menu">
-      <li class="nav-item">
-        <a href="#" class="active" data-tab="dashboard">
-          <span class="nav-icon">📊</span>
-          <span>Panel Główny</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="timeline">
-          <span class="nav-icon">📅</span>
-          <span>Harmonogram</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="budget">
-          <span class="nav-icon">💰</span>
-          <span>Budżet</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="tasks">
-          <span class="nav-icon">✅</span>
-          <span>Zadania</span>
-          <span class="nav-badge hidden" id="tasks-badge">0</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="projects">
-          <span class="nav-icon">🏡</span>
-          <span>Projekty Domów</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="links">
-          <span class="nav-icon">🔗</span>
-          <span>Linki i Zasoby</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="contractors">
-          <span class="nav-icon">👷</span>
-          <span>Wykonawcy</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="materials">
-          <span class="nav-icon">🧱</span>
-          <span>Materiały</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="weather">
-          <span class="nav-icon">🌤️</span>
-          <span>Pogoda</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a href="#" data-tab="notes">
-          <span class="nav-icon">📝</span>
-          <span>Notatki</span>
-        </a>
-      </li>
-    </ul>
+  <main class="module-content">
+    <div class="wrap">
+      <nav class="page-tabs house-tabs" id="nav-menu">
+        <button type="button" class="page-tab active" data-tab="dashboard"><span class="nav-icon">📊</span><span>Panel główny</span></button>
+        <button type="button" class="page-tab" data-tab="timeline"><span class="nav-icon">📅</span><span>Harmonogram</span></button>
+        <button type="button" class="page-tab" data-tab="budget"><span class="nav-icon">💰</span><span>Budżet</span></button>
+        <button type="button" class="page-tab" data-tab="tasks"><span class="nav-icon">✅</span><span>Zadania</span><span class="nav-badge hidden" id="tasks-badge">0</span></button>
+        <button type="button" class="page-tab" data-tab="projects"><span class="nav-icon">🏡</span><span>Projekty domów</span></button>
+        <button type="button" class="page-tab" data-tab="links"><span class="nav-icon">🔗</span><span>Linki i zasoby</span></button>
+        <button type="button" class="page-tab" data-tab="contractors"><span class="nav-icon">👷</span><span>Wykonawcy</span></button>
+        <button type="button" class="page-tab" data-tab="materials"><span class="nav-icon">🧱</span><span>Materiały</span></button>
+        <button type="button" class="page-tab" data-tab="weather"><span class="nav-icon">🌤️</span><span>Pogoda</span></button>
+        <button type="button" class="page-tab" data-tab="notes"><span class="nav-icon">📝</span><span>Notatki</span></button>
+      </nav>
 
-    <div class="sidebar-footer">
-      <button class="btn" style="width: 100%;" onclick="openSettingsModal()">⚙️ Ustawienia</button>
-    </div>
-  </aside>
-  
-  <div id="app-overlay"></div>
-
-  <!-- Main Wrapper -->
-  <div class="main-wrapper">
-    <!-- Topbar -->
-    <header class="topbar">
-      <div class="topbar-left">
-        <button class="btn btn-ghost btn-icon mobile-only" id="menu-toggle">☰</button>
-        <div class="page-title" id="page-title">
-          <span id="page-icon">📊</span>
-          <span id="page-name">Panel Główny</span>
-        </div>
-      </div>
-      <div class="topbar-right">
-        <button class="btn btn-ghost btn-icon" onclick="exportData()" title="Eksport danych">📥</button>
-        <button class="btn btn-ghost btn-icon" onclick="importData()" title="Import danych">📤</button>
-        <button class="btn btn-ghost btn-icon" onclick="generateReport()" title="Generuj raport">📋</button>
-        <button class="btn btn-ghost btn-icon" id="theme-toggle" onclick="toggleTheme()">🌙</button>
-      </div>
-    </header>
-
-    <!-- Main Content -->
-    <main class="main-content" id="main-content">
-      <!-- Dashboard Tab -->
-      <div id="dashboard" class="tab-panel">
+      <div id="main-content" class="module-panels">
+        <div id="dashboard" class="tab-panel">
         <div class="grid grid-4 mb-4">
           <div class="stat-card">
             <div class="stat-card-icon primary">📊</div>
@@ -2303,8 +2309,9 @@
           <div id="notes-list" class="grid grid-3"></div>
         </div>
       </div>
-    </main>
-  </div>
+      </div>
+    </div>
+  </main>
 
   <!-- Quick Actions -->
   <div class="quick-actions">
@@ -2336,6 +2343,22 @@
   <script>
     // App State
     const APP_KEY = 'buildmaster_pro_v11';
+    const safeParse = (raw, fallbackFactory) => {
+      const fallback = () => (typeof fallbackFactory === 'function' ? fallbackFactory() : fallbackFactory);
+      if (!raw) return fallback();
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : fallback();
+      } catch {
+        return fallback();
+      }
+    };
+    const deepClone = (value) => {
+      if (typeof structuredClone === 'function') {
+        try { return structuredClone(value); } catch (error) { /* ignore */ }
+      }
+      return JSON.parse(JSON.stringify(value));
+    };
     let state = {};
     const defaultState = {
       theme: 'light',
@@ -2414,17 +2437,14 @@
 
     // State Management
     function loadState() {
-      const saved = localStorage.getItem(APP_KEY);
-      if (saved) {
-        state = JSON.parse(saved);
-        // Ensure all keys from default state exist
-        for (const key in defaultState) {
-          if (typeof state[key] === 'undefined') {
-            state[key] = defaultState[key];
+      const savedState = safeParse(localStorage.getItem(APP_KEY), () => null);
+      state = deepClone(defaultState);
+      if (savedState && typeof savedState === 'object') {
+        for (const key of Object.keys(savedState)) {
+          if (typeof savedState[key] !== 'undefined') {
+            state[key] = savedState[key];
           }
         }
-      } else {
-        state = JSON.parse(JSON.stringify(defaultState));
       }
     }
 
@@ -2465,28 +2485,27 @@
 
     // Navigation
     function switchTab(tabName) {
-      document.querySelectorAll('.nav-item a').forEach(link => {
-        link.classList.toggle('active', link.dataset.tab === tabName);
+      document.querySelectorAll('#nav-menu [data-tab]').forEach(control => {
+        control.classList.toggle('active', control.dataset.tab === tabName);
       });
 
       document.querySelectorAll('.tab-panel').forEach(panel => {
         panel.classList.toggle('hidden', panel.id !== tabName);
       });
-      
-      const mainContent = document.getElementById('main-content');
-      mainContent.scrollTop = 0; // Scroll to top on tab change
 
-      const activeLink = document.querySelector(`.nav-item a[data-tab="${tabName}"]`);
-      if (activeLink) {
-        const icon = activeLink.querySelector('.nav-icon').textContent;
-        const name = activeLink.querySelector('span:last-child').textContent;
-        document.getElementById('page-icon').textContent = icon;
-        document.getElementById('page-name').textContent = name;
+      const mainContent = document.getElementById('main-content');
+      if (mainContent) {
+        mainContent.scrollTop = 0;
       }
-      
-      const sidebar = document.getElementById('sidebar');
-      if(sidebar.classList.contains('active')) {
-          toggleSidebar();
+
+      const activeControl = document.querySelector(`#nav-menu [data-tab="${tabName}"]`);
+      if (activeControl) {
+        const iconEl = activeControl.querySelector('.nav-icon');
+        const labelEl = activeControl.querySelector('span:not(.nav-icon):not(.nav-badge)');
+        const pageIcon = document.getElementById('page-icon');
+        const pageName = document.getElementById('page-name');
+        if (pageIcon && iconEl) pageIcon.textContent = iconEl.textContent;
+        if (pageName && labelEl) pageName.textContent = labelEl.textContent;
       }
 
       const renderFunc = `render${tabName.charAt(0).toUpperCase() + tabName.slice(1)}`;
@@ -2496,23 +2515,16 @@
     }
 
     function setupEventListeners() {
-      document.getElementById('nav-menu').addEventListener('click', e => {
-        const link = e.target.closest('a');
-        if (link && link.dataset.tab) {
-          e.preventDefault();
-          switchTab(link.dataset.tab);
-        }
-      });
-      
-      document.getElementById('menu-toggle').addEventListener('click', toggleSidebar);
-      document.getElementById('app-overlay').addEventListener('click', toggleSidebar);
-    }
-    
-    function toggleSidebar() {
-        const sidebar = document.getElementById('sidebar');
-        const overlay = document.getElementById('app-overlay');
-        sidebar.classList.toggle('active');
-        overlay.classList.toggle('active');
+      const navMenu = document.getElementById('nav-menu');
+      if (navMenu) {
+        navMenu.addEventListener('click', e => {
+          const control = e.target.closest('[data-tab]');
+          if (control && control.dataset.tab) {
+            e.preventDefault();
+            switchTab(control.dataset.tab);
+          }
+        });
+      }
     }
 
     // =================================================================
@@ -2531,11 +2543,11 @@
       
       const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0);
       const budgetPercent = project.budget > 0 ? (totalExpenses / project.budget * 100) : 0;
-      
-      const overdueTasks = tasks.filter(t => 
+
+      const overdueTasks = tasks.filter(t =>
         t.status !== 'completed' && t.endDate && new Date(t.endDate) < new Date()
       ).length;
-      
+
       const daysRemaining = project.endDate ? Math.max(0, Math.ceil(
         (new Date(project.endDate) - new Date()) / (1000 * 60 * 60 * 24)
       )) : 'N/A';
@@ -2543,12 +2555,48 @@
       document.getElementById('total-progress').textContent = `${Math.round(totalProgress)}%`;
       document.getElementById('progress-bar').style.width = `${totalProgress}%`;
       document.getElementById('budget-used').textContent = formatCurrency(totalExpenses);
-      document.getElementById('budget-percent').textContent = 
+      document.getElementById('budget-percent').textContent =
         `${Math.round(budgetPercent)}% z ${formatCurrency(project.budget)}`;
       document.getElementById('overdue-tasks').textContent = overdueTasks;
       document.getElementById('days-remaining').textContent = daysRemaining;
-      document.getElementById('end-date-display').textContent = 
+      document.getElementById('end-date-display').textContent =
         project.endDate ? `Termin: ${formatDate(project.endDate)}` : 'Brak terminu';
+
+      const heroProgress = document.getElementById('hero-progress');
+      if (heroProgress) heroProgress.textContent = `${Math.round(totalProgress)}%`;
+      const heroProgressNote = document.getElementById('hero-progress-note');
+      if (heroProgressNote) {
+        heroProgressNote.textContent = tasks.length
+          ? `${tasks.length.toLocaleString('pl-PL')} aktywnych zadań`
+          : 'Brak zadań do śledzenia';
+      }
+      const heroBudget = document.getElementById('hero-budget');
+      if (heroBudget) heroBudget.textContent = formatCurrency(totalExpenses);
+      const heroBudgetNote = document.getElementById('hero-budget-note');
+      if (heroBudgetNote) {
+        heroBudgetNote.textContent = project.budget
+          ? `z planu ${formatCurrency(project.budget)}`
+          : 'Budżet nieustawiony';
+      }
+      const heroOverdue = document.getElementById('hero-overdue');
+      if (heroOverdue) heroOverdue.textContent = overdueTasks;
+      const heroOverdueNote = document.getElementById('hero-overdue-note');
+      if (heroOverdueNote) {
+        if (overdueTasks === 0) heroOverdueNote.textContent = 'Wszystko na czas';
+        else if (overdueTasks === 1) heroOverdueNote.textContent = 'zadanie wymaga uwagi';
+        else heroOverdueNote.textContent = 'zadań wymaga uwagi';
+      }
+      const heroTimeline = document.getElementById('hero-timeline');
+      if (heroTimeline) {
+        if (typeof daysRemaining === 'number') heroTimeline.textContent = `${daysRemaining} dni`;
+        else heroTimeline.textContent = '—';
+      }
+      const heroTimelineNote = document.getElementById('hero-timeline-note');
+      if (heroTimelineNote) {
+        heroTimelineNote.textContent = project.endDate
+          ? `Do ${formatDate(project.endDate)}`
+          : 'Brak planowanej daty zakończenia';
+      }
 
       const taskBadge = document.getElementById('tasks-badge');
       if (overdueTasks > 0) {

--- a/index.html
+++ b/index.html
@@ -7,81 +7,24 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/styles.css">
   <style>
-    /* === THEME TOKENS === */
-    :root, [data-theme="light"]{
-      --accent-h: 222; --accent-s: 83%; --accent-l: 53%;
-      --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
-      --accent-weak: hsl(var(--accent-h) 60% 94%);
-      --bg:#f6f7fb; --card:#ffffff; --ink:#0f172a; --muted:#667085; --line:#e7eaf0;
-      --surface:#f9fafb;
-      --green:#059669;--red:#dc2626;--orange:#ea580c;--blue:#2563eb;--purple:#7c3aed;--yellow:#eab308;
-      --shadow-sm:0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow:0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.04);
-      --shadow-md:0 6px 16px -6px rgb(0 0 0 / 0.12);
-      --shadow-lg:0 18px 40px -15px rgb(0 0 0 / 0.18);
+    :root {
       --gradient-primary: radial-gradient(1200px 400px at 20% -10%, hsl(var(--accent-h) 80% 92%) 0%, transparent 55%),
                           radial-gradient(1000px 500px at 80% -20%, hsl(280 70% 95%) 0%, transparent 50%);
-      --scrollbar-thumb: hsl(var(--accent-h) 30% 75%);
-      --scrollbar-track: transparent;
       --ring: 2px solid hsl(var(--accent-h) var(--accent-s) 60%);
     }
 
-    * { box-sizing: border-box; }
-    html, body { height: 100%; }
-    body {
-      margin: 0; background: var(--bg); color: var(--ink);
-      font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
-      font-size: 12px; line-height: 1.5; overflow-x: hidden;
-    }
+    .grid { gap: 18px; }
+    .g-main { grid-template-columns: 2fr 1fr; align-items: start; }
+    .kpi-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .modules-grid { grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); }
+    .card { animation: fadeInUp .4s ease-out; }
 
-    /* === Motion preferences === */
-    @media (prefers-reduced-motion: reduce){
-      * { animation: none !important; transition: none !important }
-    }
-
-    /* === Animations === */
-    @keyframes fadeInUp { from{opacity:0; transform:translateY(10px)} to{opacity:1; transform:translateY(0)} }
     @keyframes slideInRight { from{opacity:0; transform:translateX(12px)} to{opacity:1; transform:translateX(0)} }
 
-    /* === Layout === */
-    .wrap { max-width: 1280px; margin: 0 auto; padding: 28px 20px; }
-    .grid { display: grid; gap: 14px; }
-    .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .g-main { grid-template-columns: 2fr 1fr; align-items: start; }
-    .modules-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
-
-    @media(max-width:1200px){ .kpi-grid { grid-template-columns: repeat(2,1fr) } }
-    @media(max-width:900px){ .g-main{ grid-template-columns: 1fr } }
-    @media(max-width:700px){ .g-2{ grid-template-columns: 1fr } }
-
-    /* === Cards & elements === */
-    .card{
-      background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 18px;
-      box-shadow: var(--shadow); transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
-      animation: fadeInUp .4s ease-out;
-    }
-    .card:hover{ transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: hsl(var(--accent-h) 30% 80% / .5) }
-
-    .title { margin: 0 0 10px 0; font-weight: 700; font-size: 15px; letter-spacing: .2px; }
-    .muted { color: var(--muted); }
-    .tiny { font-size: 10px }
-
-    .pill{
-      display:inline-flex; align-items:center; gap:8px; padding:6px 12px; border-radius:999px;
-      background: var(--accent-weak); color: hsl(var(--accent-h) 25% 30%); font-size:10px; font-weight:600;
-      border: 1px solid hsl(var(--accent-h) 40% 82% / .7);
-    }
-
-    .btn{
-      display:inline-flex; gap:8px; align-items:center; justify-content:center;
-      border-radius: 12px; padding: 10px 16px; border: 1px solid var(--line);
-      background: var(--surface); color: var(--ink); cursor:pointer; text-decoration:none; font-weight:600;
-      transition: transform .15s ease, box-shadow .15s ease, background .2s ease, border-color .2s ease;
-    }
-    .btn:hover{ transform: translateY(-1px); box-shadow: var(--shadow-sm); border-color:hsl(var(--accent-h) 30% 75% / .6) }
-    .btn.primary{ background: var(--accent); color:#fff; border-color: transparent }
-    .btn:focus-visible{ outline: none; box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 60% / .35) }
+    @media(max-width:1200px){ .kpi-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
+    @media(max-width:900px){ .g-main{ grid-template-columns: 1fr; } }
 
     .tile{
       cursor:pointer; display:flex; flex-direction:column; gap:10px; border-radius:16px; border:1px solid var(--line);
@@ -94,9 +37,6 @@
     }
     .tile:hover{ transform: translateY(-3px); box-shadow: var(--shadow-md); border-color:hsl(var(--accent-h) 30% 70%) }
     .tile:hover::before{ transform: scaleX(1) }
-    
-    .progress{ height:8px; background:#e2e8f0; border-radius: 999px; overflow:hidden; margin-top:8px; position:relative }
-    .progress > i{ display:block; height:100%; background: var(--accent); border-radius:inherit; transition: width 1s ease-out }
 
     /* === New KPI Tiles === */
     .kpi-tile-large {
@@ -113,30 +53,31 @@
     }
     .kpi-header { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 14px; }
     .kpi-main-value { font-size: 24px; font-weight: 800; line-height: 1.1; }
-    .kpi-details { font-size: 11px; color: var(--muted); line-height: 1.4; }
+    .kpi-details { display:flex; flex-direction:column; gap:4px; font-size: 11px; color: var(--muted); line-height: 1.45; }
+    .kpi-detail-line { position: relative; padding-left: 12px; }
+    .kpi-detail-line::before { content:'•'; position:absolute; left:0; color: var(--muted); font-weight:700; }
     .kpi-progress-container { margin-top: auto; padding-top: 8px; }
     .value-ok { color: var(--green); }
     .value-warn { color: var(--orange); }
     .value-bad { color: var(--red); }
 
-
     /* === Hero === */
     .hero-header{
-      margin:-28px -20px 24px -20px; padding: 24px 20px; color: var(--ink); position:relative; overflow:hidden;
+      margin:-32px -20px 18px -20px; padding: 20px 20px; color: var(--ink); position:relative; overflow:hidden;
       background: var(--gradient-primary);
       border-bottom: 1px solid var(--line);
     }
     .hero-content{
         position:relative; z-index:1; max-width:1280px; margin:0 auto;
         width: 100%;
+        display:flex; align-items:center; justify-content: space-between; gap: 24px;
     }
+    .hero-intro{ display:flex; flex-direction:column; gap:6px; }
     .greeting-text{ font-size: clamp(20px, 4vw, 28px); font-weight:800; margin:0 0 6px 0; animation: fadeInUp .5s ease-out }
     .date-text{ opacity:.9; font-size: 13px; margin:0 0 10px 0; animation: fadeInUp .5s ease-out .1s both }
     .dynamic-message{ font-style: italic; opacity:.85; font-size:12px; animation: fadeInUp .5s ease-out .2s both }
 
-    .quick-actions{
-      position:absolute; top:16px; right:16px; display:flex; gap:10px; animation: slideInRight .5s ease-out .2s both;
-    }
+    .quick-actions{ display:flex; gap:10px; animation: slideInRight .5s ease-out .2s both; }
     .quick-action{
       width:42px; height:42px; background: hsl(0 0% 100% / .6);
       border:1px solid hsl(0 0% 100% / .7); border-radius:10px; display:flex; align-items:center; justify-content:center;
@@ -146,25 +87,15 @@
 
     /* === Lists & feeds === */
     .activity-feed{ max-height: 300px; overflow-y:auto; padding-right:6px }
-    .activity-item{ display:flex; align-items:center; gap:12px; padding:10px 0; border-bottom:1px solid var(--line); animation: fadeInUp .35s ease-out }
+    .activity-item{ display:flex; align-items:center; gap:12px; padding:10px 0; border-bottom:1px solid var(--line); animation:fadeInUp .35s ease-out }
     .activity-item:last-child{ border-bottom:none }
 
     /* === Upcoming tasks === */
-    .priorities-card{
-        display:flex; flex-direction:column; border:none; background: var(--card);
-        flex-grow: 1;
-    }
+    .priorities-card{ display:flex; flex-direction:column; background: var(--card); flex-grow: 1; }
     .upcoming-header{ display:flex; justify-content:space-between; align-items:baseline; margin-bottom:12px }
-    #upcoming-tasks-list{
-        overflow:auto; padding-right:6px; flex-grow: 1;
-    }
-    #upcoming-tasks-list::-webkit-scrollbar, .activity-feed::-webkit-scrollbar{ width: 10px }
-    #upcoming-tasks-list::-webkit-scrollbar-thumb, .activity-feed::-webkit-scrollbar-thumb{
-      background: var(--scrollbar-thumb); border-radius: 8px; border: 2px solid transparent; background-clip: content-box;
-    }
-    #upcoming-tasks-list{ scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track) }
+    #upcoming-tasks-list{ overflow:auto; padding-right:6px; flex-grow: 1; }
     .task-group-header {
-      font-size: 9px; text-transform: uppercase; color: var(--muted); margin: 16px 0 4px 4px; font-weight: 600; letter-spacing: 0.5px;
+      font-size: 9px; text-transform: uppercase; color: var(--muted); margin: 16px 0 4px 4px; font-weight: 600; letter-spacing:0.5px;
     }
     .task-group-header:first-of-type { margin-top: 0; }
     .upcoming-task-item{
@@ -224,11 +155,10 @@
     }
     @keyframes spin{ to{ transform: translate(-50%,-50%) rotate(360deg) } }
 
-    /* === Responsive === */
     @media (max-width: 768px){
-      .hero-header{ padding: 22px; margin:-28px -20px 18px -20px }
-      .quick-actions{ position: static; margin-top: 12px; justify-content: center }
-      .wrap{ padding: 16px }
+      .hero-header{ padding: 24px; margin:-28px -20px 20px -20px }
+      .hero-content{ flex-direction: column; align-items: flex-start; gap: 16px; }
+      .quick-actions{ width: 100%; justify-content: flex-start; }
     }
   </style>
 </head>
@@ -236,13 +166,15 @@
   <div class="wrap">
     <header class="hero-header">
       <div class="hero-content">
+        <div class="hero-intro">
+          <h1 id="greeting" class="greeting-text">Dzień dobry!</h1>
+          <p id="current-date" class="date-text"></p>
+          <p id="dynamic-message" class="dynamic-message"></p>
+        </div>
         <div class="quick-actions">
           <a href="#" class="quick-action" title="Ustawienia" onclick="openSettingsModal()">⚙️</a>
           <a href="#" class="quick-action" title="Odśwież" onclick="refreshDashboard()">↻</a>
         </div>
-        <h1 id="greeting" class="greeting-text">Dzień dobry!</h1>
-        <p id="current-date" class="date-text"></p>
-        <p id="dynamic-message" class="dynamic-message"></p>
       </div>
     </header>
 
@@ -342,11 +274,19 @@
 const BUDGET_STORAGE_KEY = 'lifeos_budget_v4';
 const FUEL_STORAGE_KEY = 'lifeos_fuel_v1';
 const TASKS_STORAGE_KEY = 'lifeos_tasks_pro_v2';
-const TRAININGS_STORAGE_KEY = 'lifeos_trainings_v1';
+const TRAININGS_STORAGE_KEY_MODERN = 'lifeos_trainings_month_v1';
+const TRAININGS_STORAGE_KEY_LEGACY = 'lifeos_trainings_v1';
+const TRAININGS_STORAGE_KEYS = [TRAININGS_STORAGE_KEY_MODERN, TRAININGS_STORAGE_KEY_LEGACY];
 const HOUSE_STORAGE_KEY = 'buildmaster_pro_v11';
 const LOAN_STORAGE_KEY = 'lifeos_loan_v1';
 const SETTINGS_STORAGE_KEY = 'lifeos_settings_v1';
 const BACKUP_TIMESTAMP_KEY = 'lifeos_last_backup';
+
+const TRAINING_GOALS = {
+  gym: { target: 3, unit: 'sesje', name: 'Siłownia', icon: '🏋️' },
+  running: { target: 5, unit: 'km', name: 'Bieganie', icon: '🏃' },
+  reading: { target: 100, unit: 'stron', name: 'Czytanie', icon: '📚' },
+};
 
 /* === UTIL === */
 function fmt(n, c = 'PLN') {
@@ -356,6 +296,10 @@ function fmt(n, c = 'PLN') {
     parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, "\u00A0");
     return `${parts.join(',')}\u00A0${c}`;
   } catch { return `${Number(n || 0).toFixed(2)}\u00A0${c}`; }
+}
+function safeParse(raw, fallback = null){
+  if(!raw) return fallback;
+  try { return JSON.parse(raw); } catch { return fallback; }
 }
 function num(s) {
   if(typeof s === 'number') return s;
@@ -367,7 +311,81 @@ function num(s) {
 }
 function monthKey(d = new Date()) { return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`; }
 function parseDate(dateString){ if(!dateString) return null; const p = dateString.split('-').map(Number); return new Date(Date.UTC(p[0], p[1]-1, p[2])); }
+function parseLocalDate(dateString){ if(!dateString) return null; const p = dateString.split('-').map(Number); if(p.some(v=>!Number.isFinite(v))) return null; return new Date(p[0], p[1]-1, p[2]); }
 function getWeekNumber(d){ d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())); d.setUTCDate(d.getUTCDate()+4-(d.getUTCDay()||7)); const yStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return [d.getUTCFullYear(), Math.ceil((((d - yStart)/86400000)+1)/7)] }
+function getISOWeekStart(year, week){ const simple = new Date(Date.UTC(year,0,4)); simple.setUTCDate(simple.getUTCDate() + (week-1)*7); const day = simple.getUTCDay(); const diff = (day === 0 ? -6 : 1) - day; simple.setUTCDate(simple.getUTCDate()+diff); return new Date(simple.getFullYear(), simple.getMonth(), simple.getDate()); }
+function formatShortDate(date){ if(!(date instanceof Date)) return ''; const time = date.getTime(); if(Number.isNaN(time)) return ''; return date.toLocaleDateString('pl-PL',{ day:'2-digit', month:'2-digit' }); }
+function formatGoalValue(type, value){ const numValue = Number(value || 0); if(type === 'gym') return Math.max(0, Math.round(numValue)); const rounded = Math.round(numValue * 10) / 10; return Math.abs(rounded % 1) < 0.1 ? Math.round(rounded) : rounded.toFixed(1); }
+
+function normalizeFuelTransaction(tx){ if(!tx || !tx.date) return null; const normalized = { ...tx }; const rawAmount = num(tx.amount ?? tx.value); let type = (tx.type || '').toLowerCase(); if(type !== 'invoice' && type !== 'advance'){ type = rawAmount >= 0 ? 'advance' : 'invoice'; }
+  normalized.type = type;
+  normalized.amount = type === 'invoice' ? -Math.abs(rawAmount) : Math.abs(rawAmount);
+  const litersSource = tx.liters ?? tx.details?.liters ?? tx.volume;
+  const litersValue = num(litersSource);
+  normalized.liters = type === 'invoice' && litersValue > 0 ? litersValue : null;
+  if(!normalized.ref && tx.reference) normalized.ref = tx.reference;
+  return normalized;
+}
+
+function getFuelData(){ const parsed = safeParse(localStorage.getItem(FUEL_STORAGE_KEY), {}); const rawList = Array.isArray(parsed?.transactions) ? parsed.transactions : []; const normalized = rawList.map(normalizeFuelTransaction).filter(Boolean).sort((a,b)=> (b.date||'').localeCompare(a.date||'')); const invoices = normalized.filter(tx=> tx.type === 'invoice'); const advances = normalized.filter(tx=> tx.type === 'advance'); return { transactions: normalized, invoices, advances };
+}
+
+function getTrainingStore(){ for(const key of TRAININGS_STORAGE_KEYS){ const raw = localStorage.getItem(key); if(!raw) continue; const parsed = safeParse(raw, null); if(parsed && typeof parsed === 'object'){ if(parsed.activities && typeof parsed.activities === 'object'){ return { type: 'modern', data: parsed }; }
+      return { type: 'legacy', data: parsed };
+    }
+  }
+  return { type: 'none', data: null };
+}
+
+function computeModernTrainingWeekStats(state, isoYear, isoWeek){ const weekStart = getISOWeekStart(isoYear, isoWeek); const weekEnd = new Date(weekStart); weekEnd.setDate(weekStart.getDate()+6); const totals = Object.fromEntries(Object.keys(TRAINING_GOALS).map(k=>[k,0])); const activities = state?.activities && typeof state.activities === 'object' ? state.activities : {};
+  Object.entries(activities).forEach(([dateStr, list])=>{
+    const day = parseLocalDate(dateStr);
+    if(!day) return;
+    day.setHours(0,0,0,0);
+    if(day < weekStart || day > weekEnd) return;
+    if(!Array.isArray(list)) return;
+    list.forEach(activity=>{
+      if(!activity || !TRAINING_GOALS[activity.type] || !activity.completed) return;
+      if(activity.type === 'gym'){ totals.gym += 1; return; }
+      const logged = Number(activity.loggedValue);
+      const planned = Number(activity.plannedValue);
+      const value = Number.isFinite(logged) && logged > 0 ? logged : (Number.isFinite(planned) ? planned : 0);
+      totals[activity.type] += value;
+    });
+  });
+  const goalPercents = {};
+  Object.entries(TRAINING_GOALS).forEach(([type, def])=>{
+    const progress = Number(totals[type] || 0);
+    const percent = def.target > 0 ? Math.min(100, Math.round((progress / def.target) * 100)) : 0;
+    goalPercents[type] = { progress, percent, target: def.target };
+  });
+  const average = Math.round(Object.values(goalPercents).reduce((sum, info)=> sum + (info.percent || 0), 0) / Object.keys(TRAINING_GOALS).length) || 0;
+  return { goalPercents, average, range: { start: weekStart, end: weekEnd } };
+}
+
+function computeModernCompletedWeeks(state, isoYear, isoWeek){ let completed = 0; for(let w = 1; w < isoWeek; w += 1){ const stats = computeModernTrainingWeekStats(state, isoYear, w); const allMet = Object.values(stats.goalPercents || {}).every(info => Number(info.percent || 0) >= 100); if(allMet) completed += 1; }
+  return completed;
+}
+
+function computeLegacyTrainingWeekStats(data, isoYear, isoWeek){ const weekStart = getISOWeekStart(isoYear, isoWeek); const weekEnd = new Date(weekStart); weekEnd.setDate(weekStart.getDate()+6); const weekData = data?.[isoYear]?.[isoWeek] || {}; const progress = weekData.progress || {}; const goalPercents = {};
+  Object.entries(TRAINING_GOALS).forEach(([type, def])=>{
+    const value = Number(progress[type] || 0);
+    const percent = def.target > 0 ? Math.min(100, Math.round((value / def.target) * 100)) : 0;
+    goalPercents[type] = { progress: value, percent, target: def.target };
+  });
+  const average = Math.round(Object.values(goalPercents).reduce((sum, info)=> sum + (info.percent || 0), 0) / Object.keys(TRAINING_GOALS).length) || 0;
+  const completedWeeks = Object.keys(data?.[isoYear] || {}).filter(wn => Number(wn) < isoWeek && data[isoYear][wn]?.isComplete).length;
+  const totalWeeks = Math.max(0, isoWeek - 1);
+  return { goalPercents, average, range: { start: weekStart, end: weekEnd }, completedWeeks, totalWeeks };
+}
+
+function getTrainingSummary(){ const now = new Date(); const [isoYear, isoWeek] = getWeekNumber(now); const totalWeeks = Math.max(0, isoWeek - 1); const store = getTrainingStore(); if(store.type === 'modern'){ const stats = computeModernTrainingWeekStats(store.data, isoYear, isoWeek); return { ...stats, completedWeeks: computeModernCompletedWeeks(store.data, isoYear, isoWeek), totalWeeks: totalWeeks };
+  }
+  if(store.type === 'legacy'){ const legacyStats = computeLegacyTrainingWeekStats(store.data, isoYear, isoWeek); if(typeof legacyStats.totalWeeks !== 'number') legacyStats.totalWeeks = totalWeeks; if(typeof legacyStats.completedWeeks !== 'number') legacyStats.completedWeeks = 0; return legacyStats; }
+  return { goalPercents: null, average: 0, range: null, completedWeeks: 0, totalWeeks };
+}
+
+function renderDetailLines(lines){ if(!Array.isArray(lines) || !lines.length) return '<div class="kpi-detail-line">Brak danych.</div>'; return lines.map(line => `<div class="kpi-detail-line">${line}</div>`).join(''); }
 
 /* === NOTIFICATION === */
 function showNotification(message, type='success'){
@@ -411,12 +429,12 @@ function renderGreetingAndDate(){
 function renderUpcomingTasks(){
   const listEl = document.getElementById('upcoming-tasks-list');
   const tasksRaw = localStorage.getItem(TASKS_STORAGE_KEY);
-  if(!tasksRaw){
+  const tasksState = safeParse(tasksRaw, { tasks: [] });
+  if(!tasksState || !Array.isArray(tasksState.tasks) || tasksState.tasks.length === 0){
     listEl.innerHTML = `<div class="tiny muted" style="padding: 14px;">Brak zadań.</div>`;
     document.getElementById('priorities-summary').textContent = 'Brak zadań';
     return;
   }
-  const tasksState = JSON.parse(tasksRaw);
   const today = new Date(); today.setUTCHours(0,0,0,0);
   
   const overdue = tasksState.tasks.filter(t => t.status !== 'done' && t.dueDate && parseDate(t.dueDate) < today).sort((a,b) => parseDate(a.dueDate)-parseDate(b.dueDate));
@@ -465,28 +483,26 @@ function renderUpcomingTasks(){
 /* === WEEKLY ACTIVITIES === */
 function renderWeeklyActivities(){
   const listEl = document.getElementById('weekly-activities-list');
-  const trainingsRaw = localStorage.getItem(TRAININGS_STORAGE_KEY);
-  const GOALS = { gym:{name:'Siłownia',icon:'🏋️',target:3,unit:'razy'}, running:{name:'Bieganie',icon:'🏃',target:5,unit:'km'}, reading:{name:'Czytanie',icon:'📚',target:100,unit:'stron'} };
-  const [y,w] = getWeekNumber(new Date());
-  let progressData = {};
-  if(trainingsRaw){ const st = JSON.parse(trainingsRaw); progressData = st[y]?.[w]?.progress || {} }
-  listEl.innerHTML = Object.entries(GOALS).map(([k,g],i)=>{
-    const current = progressData[k] || 0;
-    const pct = Math.min(100, current/g.target*100);
-    return `<div class="activity-item" style="animation-delay:${i*.05}s;">
-      <div style="font-size:20px;width:32px;text-align:center">${g.icon}</div>
+  const summary = getTrainingSummary();
+  const goalPercents = summary.goalPercents || {};
+  listEl.innerHTML = Object.entries(TRAINING_GOALS).map(([type, meta], index)=>{
+    const info = goalPercents[type] || { progress: 0, percent: 0, target: meta.target };
+    const current = formatGoalValue(type, info.progress || 0);
+    const pct = Math.max(0, Math.min(100, Number(info.percent) || 0));
+    return `<div class="activity-item" style="animation-delay:${index * 0.05}s;">
+      <div style="font-size:20px;width:32px;text-align:center">${meta.icon}</div>
       <div style="flex:1">
-        <div style="font-weight:600;display:flex;justify-content:space-between"><span>${g.name}</span><span class="tiny muted">${current} / ${g.target} ${g.unit}</span></div>
+        <div style="font-weight:600;display:flex;justify-content:space-between"><span>${meta.name}</span><span class="tiny muted">${current} / ${meta.target} ${meta.unit}</span></div>
         <div class="progress" style="height:6px;margin-top:6px"><i style="width:${pct}%"></i></div>
       </div>
-    </div>`
+    </div>`;
   }).join('');
 }
 
 /* === WEATHER (From Settings) === */
 function renderWeatherWidget() {
   const widget = document.getElementById('weather-widget');
-  const settings = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) || '{}');
+  const settings = safeParse(localStorage.getItem(SETTINGS_STORAGE_KEY), {}) || {};
   const locationQuery = settings.weatherLocation || 'Warszawa';
 
   widget.innerHTML = `<div class="muted" style="padding: 20px; text-align: center; font-size: 13px;">Ładowanie pogody dla: ${locationQuery}...</div>`;
@@ -566,7 +582,6 @@ function renderKPIs(){
 }
 
 function renderKPIData(){
-  const currency = 'PLN';
   const kpiElements = {
       budget: document.getElementById('kpi-budget'),
       fuel: document.getElementById('kpi-fuel'),
@@ -579,88 +594,113 @@ function renderKPIData(){
   // --- Budget KPI ---
   const budgetRaw = localStorage.getItem(BUDGET_STORAGE_KEY);
   if(budgetRaw){
-    const bState = JSON.parse(budgetRaw).modules.budget;
+    const parsedBudget = safeParse(budgetRaw, null);
+    const bState = parsedBudget?.modules?.budget || parsedBudget?.budget || parsedBudget;
     const ym = monthKey();
-    let budgetHTML = `
-      <div class="kpi-header"><span>💰</span><h4>Budżet</h4></div>
-      <div class="kpi-main-value">—</div>
-      <div class="kpi-details">Brak danych na ten miesiąc.</div>
-      <div class="kpi-progress-container"></div>`;
-
-    if(bState.monthly && bState.monthly[ym]){
+    if(bState && bState.monthly && bState.monthly[ym]){
       const m = bState.monthly[ym];
-      const incSum = m.incomes.reduce((s,x)=> s+num(x.amount),0);
-      const fixSum = m.fixed.reduce((s,x)=> s+num(x.amount),0);
+      const incomes = Array.isArray(m.incomes) ? m.incomes : [];
+      const fixed = Array.isArray(m.fixed) ? m.fixed : [];
+      const incSum = incomes.reduce((s,x)=> s+num(x.amount),0);
+      const fixSum = fixed.reduce((s,x)=> s+num(x.amount),0);
       const daysInMonth = new Date(ym.split('-')[0], ym.split('-')[1], 0).getDate();
       const currentDay = new Date().getDate();
-      
+
       const dailyBudget = Math.max(0, (incSum - fixSum)/daysInMonth);
       const budgetForToday = dailyBudget * currentDay;
 
-      const catsById = Object.fromEntries((bState.categories||[]).map(c=>[c.id,c]));
-      const spentUntilToday = (bState.transactions||[]).filter(t=> String(t.date||'').startsWith(ym) && new Date(t.date).getDate()<=currentDay).reduce((sum,t)=>{
+      const catsById = Object.fromEntries((Array.isArray(bState?.categories)?bState.categories:[]).map(c=>[c.id,c]));
+      const txs = Array.isArray(bState?.transactions) ? bState.transactions : [];
+      const spentUntilToday = txs.filter(t=> String(t.date||'').startsWith(ym) && new Date(t.date).getDate()<=currentDay).reduce((sum,t)=>{
         if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? ss+Math.abs(num(sp.amount)) : ss },0) }
         const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? sum+Math.abs(num(t.amount)) : sum
       },0);
-      
+
       const buffer = budgetForToday - spentUntilToday;
       const bufferClass = buffer > budgetForToday * 0.2 ? 'value-ok' : buffer >= 0 ? 'value-warn' : 'value-bad';
 
-      const totalSpentMonth = (bState.transactions||[]).filter(t=> String(t.date||'').startsWith(ym)).reduce((sum,t)=>{
+      const totalSpentMonth = txs.filter(t=> String(t.date||'').startsWith(ym)).reduce((sum,t)=>{
         if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? ss+Math.abs(num(sp.amount)) : ss },0) }
         const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? sum+Math.abs(num(t.amount)) : sum
       },0);
       const monthlyBudget = incSum;
       const spentPct = monthlyBudget > 0 ? (totalSpentMonth / monthlyBudget) * 100 : 0;
 
-      budgetHTML = `
+      const detailLines = [
+        `Dzisiejszy limit: ${fmt(dailyBudget)} • wydano ${fmt(spentUntilToday)} z ${fmt(budgetForToday)}.`,
+        `Plan miesięczny: ${fmt(monthlyBudget)} (wykorzystano ${Math.round(spentPct)}%).`
+      ];
+
+      kpiElements.budget.innerHTML = `
         <div class="kpi-header"><span>💰</span><h4>Budżet</h4></div>
         <div class="kpi-main-value ${bufferClass}">${fmt(buffer, '')}<span class="tiny muted" style="margin-left: 4px;">PLN</span></div>
-        <div class="kpi-details">
-          Zapas na dziś. Wydano ${fmt(spentUntilToday)} z ${fmt(budgetForToday)}.
-        </div>
+        <div class="kpi-details">${renderDetailLines(detailLines)}</div>
         <div class="kpi-progress-container">
           <div class="tiny muted" style="display: flex; justify-content: space-between; margin-bottom: 4px;">
-            <span>Budżet miesięczny</span><span>${spentPct.toFixed(0)}%</span>
+            <span>Budżet miesięczny</span><span>${Math.round(spentPct)}%</span>
           </div>
           <div class="progress"><i style="width:${spentPct}%"></i></div>
         </div>`;
+    } else {
+      kpiElements.budget.innerHTML = `
+        <div class="kpi-header"><span>💰</span><h4>Budżet</h4></div>
+        <div class="kpi-main-value">—</div>
+        <div class="kpi-details">${renderDetailLines(['Brak danych na ten miesiąc.'])}</div>
+        <div class="kpi-progress-container"></div>`;
     }
-    kpiElements.budget.innerHTML = budgetHTML;
   } else {
-    kpiElements.budget.innerHTML = `<div class="kpi-header"><span>💰</span><h4>Budżet</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.budget.innerHTML = `<div class="kpi-header"><span>💰</span><h4>Budżet</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 
   // --- Fuel KPI ---
-  const fuelRaw = localStorage.getItem(FUEL_STORAGE_KEY);
-  if(fuelRaw){
-    const f = JSON.parse(fuelRaw);
-    const bal = f.transactions.reduce((a,tx)=> a+num(tx.amount),0);
-    const balanceClass = bal >= 0 ? 'value-ok' : 'value-bad';
-    
-    const last = f.transactions.filter(tx=> tx.type==='invoice').sort((a,b)=> b.date.localeCompare(a.date))[0];
-    let detailsHTML = 'Brak zarejestrowanych tankowań.';
-    if(last){
-      const days = Math.floor((new Date() - new Date(last.date))/86400000);
-      const amount = Math.abs(num(last.amount));
-      const liters = num(last.details?.liters);
-      const pricePerLiter = liters > 0 ? (amount / liters).toFixed(2) : 0;
-      detailsHTML = `Ostatnie tankowanie ${days} dni temu za ${fmt(amount)} (${liters.toFixed(1)} L @ ${pricePerLiter} zł).`;
+  const fuelData = getFuelData();
+  if(fuelData.transactions.length){
+    const balance = fuelData.transactions.reduce((sum, tx)=> sum + tx.amount, 0);
+    const balanceClass = balance >= 0 ? 'value-ok' : 'value-bad';
+    const lastInvoice = fuelData.invoices[0];
+    const detailLines = [];
+    if(lastInvoice){
+      const days = lastInvoice.date ? Math.floor((new Date() - new Date(lastInvoice.date))/86400000) : null;
+      const amount = Math.abs(Number(lastInvoice.amount) || 0);
+      const liters = typeof lastInvoice.liters === 'number' ? lastInvoice.liters : num(lastInvoice.liters);
+      detailLines.push(`Ostatnie tankowanie ${days === null ? '' : `${days} dni temu `}za ${fmt(amount)}.`);
+      if(liters && liters > 0){
+        const pricePerLiter = amount / liters;
+        detailLines.push(`${liters.toFixed(1)} L @ ${fmt(pricePerLiter, 'PLN/L')}`);
+      }
+    } else {
+      detailLines.push('Brak zarejestrowanych tankowań.');
+    }
+    const lastYearStart = new Date();
+    lastYearStart.setHours(0,0,0,0);
+    lastYearStart.setMonth(lastYearStart.getMonth() - 12);
+    const invoicesLastYear = fuelData.invoices.filter(tx => {
+      const txDate = parseDate(tx.date);
+      return txDate ? txDate >= lastYearStart : false;
+    });
+    const totalCost = invoicesLastYear.reduce((sum, tx)=> sum + Math.abs(Number(tx.amount) || 0), 0);
+    const totalLiters = invoicesLastYear.reduce((sum, tx)=> sum + (Number(tx.liters) || 0), 0);
+    if(totalLiters > 0){
+      detailLines.push(`Średnia cena (12M): ${fmt(totalCost / totalLiters, 'PLN/L')} (${invoicesLastYear.length} fakt.)`);
+    } else if(invoicesLastYear.length === 0 && fuelData.invoices.length > 0){
+      detailLines.push(`Brak faktur z ostatnich 12 mies. • Łącznie ${fuelData.invoices.length}`);
+    } else {
+      detailLines.push(`${fuelData.invoices.length} faktur • ${fuelData.advances.length} zaliczek`);
     }
     kpiElements.fuel.innerHTML = `
       <div class="kpi-header"><span>⛽</span><h4>Paliwo</h4></div>
-      <div class="kpi-main-value ${balanceClass}">${fmt(bal, '')}<span class="tiny muted" style="margin-left: 4px;">PLN</span></div>
-      <div class="kpi-details">${detailsHTML}</div>`;
+      <div class="kpi-main-value ${balanceClass}">${fmt(balance, '')}<span class="tiny muted" style="margin-left: 4px;">PLN</span></div>
+      <div class="kpi-details">${renderDetailLines(detailLines)}</div>`;
   } else {
-    kpiElements.fuel.innerHTML = `<div class="kpi-header"><span>⛽</span><h4>Paliwo</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.fuel.innerHTML = `<div class="kpi-header"><span>⛽</span><h4>Paliwo</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 
   // --- Tasks KPI ---
   const tasksRaw = localStorage.getItem(TASKS_STORAGE_KEY);
   if(tasksRaw){
-    const t = JSON.parse(tasksRaw);
+    const t = safeParse(tasksRaw, { tasks: [] });
     const today = new Date(); today.setUTCHours(0,0,0,0);
-    const activeTasks = t.tasks.filter(x=> x.status!=='done');
+    const activeTasks = Array.isArray(t?.tasks) ? t.tasks.filter(x=> x.status!=='done') : [];
     const overdue = activeTasks.filter(x => x.dueDate && parseDate(x.dueDate) < today).length;
     const forToday = activeTasks.filter(x => x.dueDate && parseDate(x.dueDate).getTime() === today.getTime()).length;
     const activeCount = activeTasks.length;
@@ -671,14 +711,17 @@ function renderKPIData(){
     const end = new Date(start); end.setDate(start.getDate()+6); end.setHours(23,59,59,999);
     const weekly = t.tasks.filter(x=> x.dueDate && new Date(x.dueDate)>=start && new Date(x.dueDate)<=end);
     const done = weekly.filter(x=> x.status==='done').length;
-    const planned = weekly.length; const progress = planned>0 ? (done/planned)*100 : 0;
-    
+    const planned = weekly.length;
+    const progress = planned>0 ? (done/planned)*100 : 0;
+    const detailLines = [
+      `Zaległe: ${overdue} • Na dziś: ${forToday}.`,
+      planned > 0 ? `Postęp tygodnia: ${done}/${planned} (${Math.round(progress)}%).` : 'Brak zadań zaplanowanych na ten tydzień.'
+    ];
+
     kpiElements.tasks.innerHTML = `
       <div class="kpi-header"><span>✅</span><h4>Zadania</h4></div>
       <div class="kpi-main-value ${activeClass}">${activeCount}</div>
-      <div class="kpi-details">
-        Aktywnych zadań. W tym <span style="color:var(--red); font-weight:600;">${overdue}</span> zaległych i <span style="font-weight:600;">${forToday}</span> na dziś.
-      </div>
+      <div class="kpi-details">${renderDetailLines(detailLines)}</div>
       <div class="kpi-progress-container">
         <div class="tiny muted" style="display: flex; justify-content: space-between; margin-bottom: 4px;">
           <span>Ukończono w tym tyg.</span><span>${done}/${planned}</span>
@@ -686,57 +729,58 @@ function renderKPIData(){
         <div class="progress"><i style="width:${progress}%"></i></div>
       </div>`;
   } else {
-    kpiElements.tasks.innerHTML = `<div class="kpi-header"><span>✅</span><h4>Zadania</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.tasks.innerHTML = `<div class="kpi-header"><span>✅</span><h4>Zadania</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 
   // --- Progress KPI ---
-  const trRaw = localStorage.getItem(TRAININGS_STORAGE_KEY);
-  if(trRaw){
-    const st = JSON.parse(trRaw);
-    const [y,w] = getWeekNumber(new Date());
-    const yData = st[y] || {};
-    const wd = yData[w];
-    let avg = 0;
-    if(wd){
-      const GOALS = { gym:3, running:5, reading:100 };
-      let sum=0, cnt=0;
-      for(const k in GOALS){ if(GOALS.hasOwnProperty(k)){ sum += Math.min(100, ((wd.progress[k]||0)/GOALS[k])*100); cnt++ }}
-      avg = cnt > 0 ? sum/cnt : 0;
-    }
+  const trainingSummary = getTrainingSummary();
+  if(trainingSummary.goalPercents){
+    const avg = Number(trainingSummary.average || 0);
     const avgClass = avg > 80 ? 'value-ok' : avg > 40 ? 'value-warn' : 'value-bad';
-    const completedWeeks = Object.keys(yData).filter(wn=> parseInt(wn)<w && yData[wn].isComplete).length;
+    const totalWeeks = typeof trainingSummary.totalWeeks === 'number' ? trainingSummary.totalWeeks : Math.max(0, getWeekNumber(new Date())[1] - 1);
+    const completedWeeks = trainingSummary.completedWeeks || 0;
+    const detailLines = [];
+    if(trainingSummary.range){
+      detailLines.push(`Zakres: ${formatShortDate(trainingSummary.range.start)} – ${formatShortDate(trainingSummary.range.end)}.`);
+    }
+    Object.entries(TRAINING_GOALS).forEach(([type, def])=>{
+      const info = trainingSummary.goalPercents?.[type] || { progress: 0, target: def.target };
+      detailLines.push(`${def.name}: ${formatGoalValue(type, info.progress || 0)} / ${def.target} ${def.unit}`);
+    });
+    detailLines.push(`W pełni zrealizowane tygodnie: ${completedWeeks}/${totalWeeks}.`);
 
     kpiElements.progress.innerHTML = `
       <div class="kpi-header"><span>💪</span><h4>Progres</h4></div>
       <div class="kpi-main-value ${avgClass}">${Math.round(avg)}<span class="tiny muted" style="margin-left: 4px;">%</span></div>
-      <div class="kpi-details">
-        Średni postęp w tym tygodniu. Ukończono <span style="font-weight:600;">${completedWeeks} z ${w-1}</span> poprzednich tyg. w tym roku.
-      </div>
-       <div class="kpi-progress-container">
+      <div class="kpi-details">${renderDetailLines(detailLines)}</div>
+      <div class="kpi-progress-container">
           <div class="tiny muted" style="display: flex; justify-content: space-between; margin-bottom: 4px;">
             <span>Postęp w tym tyg.</span>
           </div>
-          <div class="progress"><i style="width:${avg}%"></i></div>
+          <div class="progress"><i style="width:${Math.min(100, Math.max(0, avg))}%"></i></div>
       </div>`;
   } else {
-    kpiElements.progress.innerHTML = `<div class="kpi-header"><span>💪</span><h4>Progres</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.progress.innerHTML = `<div class="kpi-header"><span>💪</span><h4>Progres</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 
   // --- House KPI ---
   const houseRaw = localStorage.getItem(HOUSE_STORAGE_KEY);
   if(houseRaw){
-    const hState = JSON.parse(houseRaw);
-    const { tasks, expenses, project } = hState;
-    const completedTasksProgress = tasks.map(t => (t.progress || 0));
+    const hState = safeParse(houseRaw, {});
+    const tasks = Array.isArray(hState?.tasks) ? hState.tasks : [];
+    const expenses = Array.isArray(hState?.expenses) ? hState.expenses : [];
+    const completedTasksProgress = tasks.map(t => Number(t.progress || 0));
     const totalProgress = tasks.length > 0 ? completedTasksProgress.reduce((a,b) => a + b, 0) / tasks.length : 0;
-    const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0);
-      
+    const totalExpenses = expenses.reduce((sum, e) => sum + num(e.amount), 0);
+
+    const detailLines = [
+      `${tasks.length} zadań • ${expenses.length} wydatków.`,
+      `Średni postęp zadań: ${tasks.length ? totalProgress.toFixed(0) : 0}%`
+    ];
     kpiElements.house.innerHTML = `
       <div class="kpi-header"><span>🏗️</span><h4>Budowa</h4></div>
       <div class="kpi-main-value">${fmt(totalExpenses)}</div>
-      <div class="kpi-details">
-        Całkowite wydatki projektu.
-      </div>
+      <div class="kpi-details">${renderDetailLines(detailLines)}</div>
       <div class="kpi-progress-container">
         <div class="tiny muted" style="display: flex; justify-content: space-between; margin-bottom: 4px;">
           <span>Całkowity postęp prac</span><span>${totalProgress.toFixed(0)}%</span>
@@ -744,26 +788,29 @@ function renderKPIData(){
         <div class="progress"><i style="width:${totalProgress}%"></i></div>
       </div>`;
   } else {
-    kpiElements.house.innerHTML = `<div class="kpi-header"><span>🏗️</span><h4>Budowa</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.house.innerHTML = `<div class="kpi-header"><span>🏗️</span><h4>Budowa</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 
   // --- Loan KPI ---
   const loanRaw = localStorage.getItem(LOAN_STORAGE_KEY);
   if(loanRaw){
-    const lState = JSON.parse(loanRaw);
-    if (lState.loanDetails) {
-      const { loanDetails, payments } = lState;
+    const lState = safeParse(loanRaw, {});
+    if (lState && lState.loanDetails) {
+      const loanDetails = lState.loanDetails;
+      const payments = Array.isArray(lState.payments) ? lState.payments : [];
       const totalOverpayments = payments.reduce((sum, p) => sum + (p.overpayment || 0), 0);
       const totalCapitalPaid = payments.reduce((sum, p) => sum + p.capital, 0) + totalOverpayments;
       const capitalRemaining = loanDetails.totalCapital - totalCapitalPaid;
       const progress = (totalCapitalPaid / loanDetails.totalCapital) * 100;
 
+      const detailLines = [
+        `Spłacono kapitału: ${fmt(totalCapitalPaid)}.`,
+        `Nadpłaty: ${fmt(totalOverpayments)}.`
+      ];
       kpiElements.loan.innerHTML = `
         <div class="kpi-header"><span>🏦</span><h4>Kredyt</h4></div>
         <div class="kpi-main-value">${fmt(capitalRemaining, '')}<span class="tiny muted" style="margin-left: 4px;">PLN</span></div>
-        <div class="kpi-details">
-          Pozostało do spłaty. Spłacono ${fmt(totalCapitalPaid)}.
-        </div>
+        <div class="kpi-details">${renderDetailLines(detailLines)}</div>
         <div class="kpi-progress-container">
           <div class="tiny muted" style="display: flex; justify-content: space-between; margin-bottom: 4px;">
             <span>Postęp spłaty</span><span>${progress.toFixed(1)}%</span>
@@ -771,10 +818,10 @@ function renderKPIData(){
           <div class="progress"><i style="width:${progress}%"></i></div>
         </div>`;
     } else {
-       kpiElements.loan.innerHTML = `<div class="kpi-header"><span>🏦</span><h4>Kredyt</h4></div><div class="kpi-details">Brak skonfigurowanego kredytu.</div>`;
+       kpiElements.loan.innerHTML = `<div class="kpi-header"><span>🏦</span><h4>Kredyt</h4></div><div class="kpi-details">${renderDetailLines(['Brak skonfigurowanego kredytu.'])}</div>`;
     }
   } else {
-    kpiElements.loan.innerHTML = `<div class="kpi-header"><span>🏦</span><h4>Kredyt</h4></div><div class="kpi-details">Brak danych.</div>`;
+    kpiElements.loan.innerHTML = `<div class="kpi-header"><span>🏦</span><h4>Kredyt</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
   }
 }
 
@@ -860,11 +907,13 @@ const exportBtn = document.getElementById('export-all-btn');
 const importBtn = document.getElementById('import-all-btn');
 const importInput = document.getElementById('import-file-input');
 exportBtn.onclick = ()=>{
+  const trainingRaw = TRAININGS_STORAGE_KEYS.map(key => localStorage.getItem(key)).find(Boolean);
+  const trainingData = trainingRaw ? safeParse(trainingRaw, null) : null;
   const allData = {
     budget: JSON.parse(localStorage.getItem(BUDGET_STORAGE_KEY) || 'null'),
     fuel: JSON.parse(localStorage.getItem(FUEL_STORAGE_KEY) || 'null'),
     tasks_pro: JSON.parse(localStorage.getItem(TASKS_STORAGE_KEY) || 'null'),
-    trainings: JSON.parse(localStorage.getItem(TRAININGS_STORAGE_KEY) || 'null'),
+    trainings: trainingData,
     house: JSON.parse(localStorage.getItem(HOUSE_STORAGE_KEY) || 'null'),
     loan: JSON.parse(localStorage.getItem(LOAN_STORAGE_KEY) || 'null'),
     settings: JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) || 'null'),
@@ -886,7 +935,10 @@ importInput.onchange = (e)=>{
       if(data.budget) localStorage.setItem(BUDGET_STORAGE_KEY, JSON.stringify(data.budget));
       if(data.fuel) localStorage.setItem(FUEL_STORAGE_KEY, JSON.stringify(data.fuel));
       if(data.tasks_pro) localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(data.tasks_pro));
-      if(data.trainings) localStorage.setItem(TRAININGS_STORAGE_KEY, JSON.stringify(data.trainings));
+      if(data.trainings){
+        localStorage.setItem(TRAININGS_STORAGE_KEY_MODERN, JSON.stringify(data.trainings));
+        localStorage.removeItem(TRAININGS_STORAGE_KEY_LEGACY);
+      }
       if(data.house) localStorage.setItem(HOUSE_STORAGE_KEY, JSON.stringify(data.house));
       if(data.loan) localStorage.setItem(LOAN_STORAGE_KEY, JSON.stringify(data.loan));
       if(data.settings) localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data.settings));

--- a/loan.html
+++ b/loan.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
   <style>
@@ -79,7 +80,25 @@
     .kpi-value { font-size: 28px; font-weight: 700; line-height: 1.2; }
     .kpi-value .currency { font-size: 16px; font-weight: 600; color: var(--muted); margin-left: 4px; }
     .kpi-sub { font-size: 12px; color: var(--muted); }
-    
+
+    .insights-grid {
+        display: grid;
+        gap: 14px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    .insight-card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+    .insight-card .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+    .insight-card .value { font-size: 22px; font-weight: 700; }
+    .insight-card .note { font-size: 12px; color: var(--muted); }
+
     .progress-bar { background: #e2e8f0; border-radius: 8px; height: 16px; overflow: hidden; }
     .progress-bar-inner {
       height: 100%;
@@ -94,6 +113,12 @@
     td { vertical-align: middle; }
     th { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; }
     tbody tr:hover { background-color: var(--surface); }
+
+    .rate-history-list { display: flex; flex-direction: column; gap: 10px; }
+    .rate-history-entry { display: flex; justify-content: space-between; align-items: baseline; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); }
+    .rate-history-entry.current { border-color: var(--accent); background: var(--accent-weak); }
+    .rate-history-entry .rate { font-weight: 700; font-size: 16px; }
+    .rate-history-entry .date { font-size: 12px; color: var(--muted); }
 
     .modal-overlay{
       position:fixed; inset:0; background: rgba(15,23,42,.6); display:flex; justify-content:center; align-items:flex-start;
@@ -125,19 +150,56 @@
     .setup-icon { font-size: 48px; margin-bottom: 16px; }
   </style>
 </head>
-<body>
+<body class="module-shell">
 
-  <div class="wrap">
-    <header class="header">
-      <h1 class="header-title">🏦 Monitor Kredytu</h1>
-      <div class="header-actions">
-        <a href="index.html" class="btn">❮ Powrót</a>
-        <button class="btn primary" id="add-payment-btn" style="display: none;">+ Dodaj spłatę</button>
-        <button class="btn" id="settings-btn" style="display: none;">⚙️ Ustawienia</button>
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Finanse</div>
+            <h1 class="module-title">Monitor kredytu</h1>
+            <p class="module-subtitle">Śledź saldo, nadpłaty i harmonogram spłat w jednym miejscu.</p>
+          </div>
+        </div>
+        <div class="module-hero-actions">
+          <button class="btn primary" id="add-payment-btn" style="display: none;">+ Dodaj spłatę</button>
+          <button class="btn soft" id="settings-btn" style="display: none;">⚙️ Ustawienia</button>
+        </div>
       </div>
-    </header>
+      <div class="module-hero-stats">
+        <div class="module-hero-stat neutral">
+          <span class="emoji">🏦</span>
+          <div class="stat-body">
+            <span class="label">Pozostało kapitału</span>
+            <span class="value" id="hero-capital-remaining">0 PLN</span>
+            <span class="note">Aktualne saldo kredytu</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral" id="hero-finish-chip">
+          <span class="emoji">📅</span>
+          <div class="stat-body">
+            <span class="label">Prognoza zakończenia</span>
+            <span class="value" id="hero-finish-date">—</span>
+            <span class="note" id="hero-finish-note">Dodaj raty, by zobaczyć prognozę</span>
+          </div>
+        </div>
+        <div class="module-hero-stat positive" id="hero-overpay-chip">
+          <span class="emoji">🚀</span>
+          <div class="stat-body">
+            <span class="label">Łączne nadpłaty</span>
+            <span class="value" id="hero-overpayments">0 PLN</span>
+            <span class="note">Skracają czas spłaty</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-    <main id="app-container">
+  <main class="module-content">
+    <div class="wrap">
+      <div id="app-container">
       
       <div id="setup-container" class="card setup-container" style="display: none;">
         <div class="setup-icon">📊</div>
@@ -171,9 +233,14 @@
             <div id="payments-sub" class="kpi-sub"></div>
           </div>
            <div class="card kpi-card">
-            <div class="kpi-label">Kredyt skrócony o</div>
-            <div id="time-saved" class="kpi-value"></div>
+           <div class="kpi-label">Kredyt skrócony o</div>
+           <div id="time-saved" class="kpi-value"></div>
           </div>
+        </div>
+
+        <div class="card" id="loan-insights-card" style="display:none;">
+            <h3 class="title">Najbliższe kroki</h3>
+            <div id="loan-insights-grid" class="insights-grid"></div>
         </div>
 
         <div class="card">
@@ -197,7 +264,12 @@
                 <canvas id="structure-chart" style="max-height: 300px;"></canvas>
             </div>
         </div>
-        
+
+        <div class="card" id="rate-history-card">
+            <h3 class="title">Historia oprocentowania</h3>
+            <ul id="rate-history-list" class="rate-history-list list-clean"></ul>
+        </div>
+
         <div class="card">
             <h3 class="title">Historia spłat</h3>
             <div class="table-wrapper">
@@ -220,8 +292,9 @@
 
       </div>
 
-    </main>
-  </div>
+      </div>
+    </div>
+  </main>
   
   <div id="modal-overlay" class="modal-overlay" role="dialog">
     <div class="modal-card" id="modal-card">
@@ -459,10 +532,11 @@ function renderDashboard() {
     $('#overpayments-total').innerHTML = `${fmt(totalOverpayments)}<span class="currency">PLN</span>`;
     $('#interest-paid').innerHTML = `${fmt(totalInterestPaid)}<span class="currency">PLN</span>`;
     $('#payments-count').innerHTML = `${payments.length}<span class="currency">z ${loanDetails.loanTerm * 12}</span>`;
-    
+
     const originalMonths = loanDetails.loanTerm * 12;
     const monthsPaid = payments.length;
     const avgMonthlyPrincipal = monthsPaid > 0 ? payments.reduce((s, p) => s + p.capital, 0) / monthsPaid : 0;
+    const avgInstallment = monthsPaid > 0 ? payments.reduce((s, p) => s + p.capital + p.interest + (p.overpayment || 0), 0) / monthsPaid : 0;
     const projectedMonthsRemaining = avgMonthlyPrincipal > 0 ? capitalRemaining / avgMonthlyPrincipal : Infinity;
     const monthsSaved = originalMonths - monthsPaid - projectedMonthsRemaining;
 
@@ -477,10 +551,42 @@ function renderDashboard() {
     const projectedEndDate = new Date();
     projectedEndDate.setMonth(projectedEndDate.getMonth() + projectedMonthsRemaining);
     $('#payments-sub').textContent = `Nowy przewidywany koniec: ${projectedEndDate.toLocaleDateString('pl-PL', {year: 'numeric', month: 'long'})}`;
-    
+
+    const heroCapital = $('#hero-capital-remaining');
+    if (heroCapital) heroCapital.textContent = fmt(capitalRemaining);
+    const heroOverpayments = $('#hero-overpayments');
+    if (heroOverpayments) heroOverpayments.textContent = fmt(totalOverpayments);
+
+    let heroFinishLabel = '—';
+    let heroFinishNote = 'Dodaj raty, by zobaczyć prognozę';
+    if (projectedMonthsRemaining && isFinite(projectedMonthsRemaining)) {
+        const finishDate = new Date();
+        finishDate.setMonth(finishDate.getMonth() + Math.max(0, Math.round(projectedMonthsRemaining)));
+        heroFinishLabel = finishDate.toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+        heroFinishNote = `${Math.round(projectedMonthsRemaining)} mies. do spłaty`;
+    }
+    const heroFinish = $('#hero-finish-date');
+    if (heroFinish) heroFinish.textContent = heroFinishLabel;
+    const heroFinishNoteEl = $('#hero-finish-note');
+    if (heroFinishNoteEl) heroFinishNoteEl.textContent = heroFinishNote;
+
     $('#progress-bar-inner').style.width = `${progress}%`;
     $('#progress-percent').textContent = `${progress.toFixed(2)}%`;
     $('#progress-text').textContent = `${fmt(totalCapitalPaid)} / ${fmt(loanDetails.totalCapital)}`;
+
+    const nextPaymentMonth = getNextPaymentMonth(payments, loanDetails);
+    updateLoanInsights({
+        loanDetails,
+        payments,
+        capitalRemaining,
+        totalCapitalPaid,
+        totalOverpayments,
+        avgMonthlyPrincipal,
+        avgInstallment,
+        projectedMonthsRemaining,
+        nextPaymentMonth
+    });
+    renderRateHistory(loanDetails, nextPaymentMonth);
 }
 
 function renderHistoryTable() {
@@ -536,6 +642,114 @@ function getRateForDate(paymentDate, history) {
         }
     }
     return currentRate;
+}
+
+function getNextPaymentMonth(payments, loanDetails) {
+    const sorted = [...payments].filter(p => p.date).sort((a, b) => a.date.localeCompare(b.date));
+    if (sorted.length) {
+        const [year, month] = sorted[sorted.length - 1].date.split('-').map(Number);
+        const next = new Date(Date.UTC(year, month - 1, 1));
+        next.setUTCMonth(next.getUTCMonth() + 1);
+        return `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}`;
+    }
+    if (loanDetails?.startDate) {
+        return loanDetails.startDate.slice(0, 7);
+    }
+    const history = loanDetails?.interestRateHistory || [];
+    if (history.length) {
+        return history[0].date;
+    }
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function updateLoanInsights(metrics) {
+    const card = $('#loan-insights-card');
+    const grid = $('#loan-insights-grid');
+    if (!card || !grid) return;
+
+    if (!metrics || !metrics.loanDetails) {
+        card.style.display = 'none';
+        return;
+    }
+
+    card.style.display = 'block';
+    const { loanDetails, payments, capitalRemaining, totalCapitalPaid, totalOverpayments, avgMonthlyPrincipal, avgInstallment, projectedMonthsRemaining, nextPaymentMonth } = metrics;
+    const paymentsList = payments || [];
+    const avgInterestPortion = paymentsList.length ? paymentsList.reduce((sum, p) => sum + p.interest, 0) / paymentsList.length : 0;
+    const nextRate = getRateForDate(nextPaymentMonth, loanDetails.interestRateHistory || []);
+    const nextLabel = new Date(`${nextPaymentMonth}-01`).toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+
+    const recommendedOverpayment = (avgMonthlyPrincipal > 0 && projectedMonthsRemaining && isFinite(projectedMonthsRemaining) && projectedMonthsRemaining > 6)
+        ? Math.max(0, (capitalRemaining / Math.max(projectedMonthsRemaining - 6, 1)) - avgMonthlyPrincipal)
+        : 0;
+
+    const finishDate = new Date();
+    if (projectedMonthsRemaining && isFinite(projectedMonthsRemaining)) {
+        finishDate.setMonth(finishDate.getMonth() + Math.max(0, Math.round(projectedMonthsRemaining)));
+    }
+    const finishLabel = projectedMonthsRemaining && isFinite(projectedMonthsRemaining)
+        ? finishDate.toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' })
+        : '—';
+
+    const cards = [
+        {
+            label: 'Następna rata',
+            value: nextLabel,
+            note: `Oprocentowanie ${nextRate ? Number(nextRate).toFixed(2) : '0.00'}%`
+        },
+        {
+            label: 'Prognozowany koniec',
+            value: finishLabel,
+            note: projectedMonthsRemaining && isFinite(projectedMonthsRemaining)
+                ? `${Math.round(projectedMonthsRemaining)} mies. do spłaty`
+                : 'Dodaj więcej rat, aby obliczyć prognozę'
+        },
+        {
+            label: 'Średnia rata',
+            value: paymentsList.length ? fmt(avgInstallment) : '—',
+            note: paymentsList.length ? `Kapitał ${fmt(avgMonthlyPrincipal)} • Odsetki ${fmt(avgInterestPortion)}` : 'Brak danych o ratach'
+        },
+        {
+            label: 'Nadpłaty',
+            value: fmt(totalOverpayments),
+            note: recommendedOverpayment > 0 ? `Dodatkowe ${fmt(recommendedOverpayment)} skróci spłatę o ~6 mies.` : 'Nadpłaty przyspieszą zakończenie kredytu'
+        }
+    ];
+
+    grid.innerHTML = cards.map(card => `
+        <div class="insight-card">
+            <div class="label">${card.label}</div>
+            <div class="value">${card.value}</div>
+            <div class="note">${card.note}</div>
+        </div>
+    `).join('');
+}
+
+function renderRateHistory(loanDetails, nextPaymentMonth) {
+    const list = $('#rate-history-list');
+    if (!list) return;
+    const history = loanDetails?.interestRateHistory || [];
+    if (!history.length) {
+        list.innerHTML = '<li class="muted" style="padding: 8px 0;">Brak historii zmian oprocentowania.</li>';
+        return;
+    }
+
+    const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
+    const currentEntry = sorted.reduce((acc, entry) => entry.date <= nextPaymentMonth ? entry : acc, sorted[0]);
+
+    list.innerHTML = sorted.map(entry => {
+        const dateLabel = new Date(`${entry.date}-01`).toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+        const rateValue = Number(entry.rate || 0).toFixed(2);
+        const isCurrent = currentEntry && entry.date === currentEntry.date;
+        const badge = isCurrent ? '<span class="tiny" style="margin-left:8px; color:var(--accent); font-weight:600;">obecna</span>' : '';
+        return `
+            <li class="rate-history-entry${isCurrent ? ' current' : ''}">
+                <span class="date">${dateLabel}${badge}</span>
+                <span class="rate">${rateValue}%</span>
+            </li>
+        `;
+    }).join('');
 }
 
 function renderCharts() {

--- a/tasks.html
+++ b/tasks.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Zadania Pro</title>
+  <link rel="stylesheet" href="assets/styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -154,22 +155,73 @@
     .segment { flex: 1; text-align: center; padding: 6px; border-radius: 8px; cursor: pointer; font-weight: 500; transition: background .2s, color .2s; }
     .segment.active { background: var(--card); box-shadow: var(--shadow-sm); color: var(--ink); }
 
+    /* Insights */
+    .insights-card { margin-bottom: 20px; }
+    .insights-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
+    .insights-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+    .insight-card { display: flex; gap: 12px; padding: 14px; border-radius: 14px; border: 1px solid var(--line); background: var(--surface); box-shadow: inset 0 1px 0 rgba(255,255,255,0.4); transition: transform .18s ease, box-shadow .18s ease; }
+    .insight-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
+    .insight-icon { width: 38px; height: 38px; border-radius: 12px; display: grid; place-items: center; font-size: 18px; font-weight: 600; background: var(--accent-weak); color: hsl(var(--accent-h) 40% 32%); }
+    .insight-content h4 { margin: 0 0 4px 0; font-size: 14px; font-weight: 700; }
+    .insight-content p { margin: 0; font-size: 12px; color: var(--muted); line-height: 1.5; }
+    .insight-card[data-tone="alert"] { border-color: rgba(234, 88, 12, 0.45); background: rgba(254, 215, 170, 0.4); }
+    .insight-card[data-tone="alert"] .insight-icon { background: rgba(251, 146, 60, 0.18); color: var(--orange); }
+    .insight-card[data-tone="success"] { border-color: rgba(5, 150, 105, 0.35); background: rgba(220, 252, 231, 0.45); }
+    .insight-card[data-tone="success"] .insight-icon { background: rgba(16, 185, 129, 0.18); color: var(--green); }
+    .insight-card[data-tone="focus"] { border-color: hsl(var(--accent-h) 50% 78% / 0.6); background: hsl(var(--accent-h) 68% 95% / 0.45); }
+    .insight-card[data-tone="focus"] .insight-icon { background: var(--accent-weak); color: hsl(var(--accent-h) 40% 35%); }
+    #insights-empty { text-align: center; }
+
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <header class="row" style="margin-bottom: 24px;">
-      <div class="row" style="gap:16px">
-        <a href="./index.html" class="btn">← Powrót</a>
-        <div>
-          <h1 style="font-size: 24px; font-weight: 800; margin:0;">Zadania Pro</h1>
-          <div class="muted">Zarządzaj swoimi obowiązkami w jednym miejscu.</div>
+<body class="module-shell">
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="./index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Produktywność</div>
+            <h1 class="module-title">Zadania Pro</h1>
+            <p class="module-subtitle">Zarządzaj wszystkimi obowiązkami w jednym miejscu i miej kontrolę nad priorytetami.</p>
+          </div>
+        </div>
+        <div class="module-hero-actions">
+          <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
         </div>
       </div>
-      <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
-    </header>
+      <div class="module-hero-stats">
+        <div class="module-hero-stat neutral">
+          <span class="emoji">📋</span>
+          <div class="stat-body">
+            <span class="label">Aktywne zadania</span>
+            <span class="value" id="hero-tasks-active">0</span>
+            <span class="note" id="hero-tasks-total-note">Brak zadań w bazie</span>
+          </div>
+        </div>
+        <div class="module-hero-stat positive" id="hero-week-chip">
+          <span class="emoji">✅</span>
+          <div class="stat-body">
+            <span class="label">Postęp w tym tygodniu</span>
+            <span class="value" id="hero-week-progress">0%</span>
+            <span class="note" id="hero-week-note">Brak zadań na ten tydzień</span>
+          </div>
+        </div>
+        <div class="module-hero-stat negative" id="hero-overdue-chip">
+          <span class="emoji">⚠️</span>
+          <div class="stat-body">
+            <span class="label">Zaległości</span>
+            <span class="value" id="hero-overdue-count">0</span>
+            <span class="note" id="hero-overdue-note">Brak zaległości</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-    <div class="card" style="margin-top:16px;">
+  <main class="module-content">
+    <div class="wrap">
+    <div class="card" style="margin-top:0;">
       <h3 class="title" id="form-title" style="margin-bottom: 16px;">Nowe zadanie</h3>
       <input type="hidden" id="task-id">
       <div class="grid" style="grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px;">
@@ -195,12 +247,23 @@
              </div>
              <ul id="subtask-list-form" style="list-style:none; padding: 0; margin: 8px 0 0 0; display:flex; flex-direction:column; gap: 4px;"></ul>
         </div>
-      </div>
+       </div>
        <div style="display:flex; gap: 8px; justify-content:flex-end; margin-top: 16px;">
           <button id="cancel-edit-btn" class="btn" style="display:none;">Anuluj</button>
           <button id="add-task-btn" class="btn primary"><span id="add-task-btn-text">Dodaj zadanie</span></button>
        </div>
     </div>
+
+    <section class="card insights-card" aria-live="polite" style="margin-top:16px;">
+      <div class="insights-header">
+        <div>
+          <h2 class="title" style="margin-bottom:4px;">Szybkie wnioski</h2>
+          <p class="muted tiny">Inteligentne podpowiedzi pomagają zaplanować kolejny krok.</p>
+        </div>
+      </div>
+      <div class="insights-grid" id="insights-grid" role="list"></div>
+      <p class="muted tiny" id="insights-empty" style="margin-top:12px; display:none;">Dodaj pierwsze zadanie, aby zobaczyć proponowane działania.</p>
+    </section>
     
     <div class="tabs" style="margin-top: 24px;">
         <div class="tab active" data-tab="list">Lista Zadań</div>
@@ -291,7 +354,8 @@
             </div>
         </div>
     </div>
-  </div>
+    </div>
+  </main>
 
 <div id="modal-overlay" class="modal-overlay" style="display: none;">
   <div class="modal-card"><p id="modal-text"></p><div id="modal-actions" class="modal-actions"></div></div>
@@ -300,6 +364,11 @@
 <script>
 // --- KONFIGURACJA ---
 const TASKS_STORAGE_KEY = 'lifeos_tasks_pro_v2';
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const PRIORITY_SET = new Set(['low', 'medium', 'high']);
+const RECURRENCE_SET = new Set(['none', 'daily', 'weekly', 'monthly']);
+const CATEGORY_SET = new Set(['work', 'private']);
+
 let state = { tasks: [] };
 let charts = {};
 let tempSubtasks = [];
@@ -309,10 +378,55 @@ let collapsedGroups = new Set();
 let draggedTaskId = null;
 const statsState = { range: 7, category: 'all' };
 
+const safeParse = (raw, fallbackFactory) => {
+    const fallback = () => (typeof fallbackFactory === 'function' ? fallbackFactory() : fallbackFactory);
+    if (!raw) return fallback();
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : fallback();
+    } catch {
+        return fallback();
+    }
+};
+
+const pluralize = (count, forms) => {
+    const mod10 = count % 10;
+    const mod100 = count % 100;
+    if (count === 1) return forms[0];
+    if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) return forms[1];
+    return forms[2];
+};
+
+function normalizeTask(raw, index) {
+    if (!raw || typeof raw !== 'object') return null;
+    const fallbackId = raw.createdAt ? `task_${raw.createdAt}` : `task_${index}`;
+    const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : fallbackId;
+    const title = typeof raw.title === 'string' && raw.title.trim() ? raw.title.trim() : 'Bez nazwy';
+    const notes = typeof raw.notes === 'string' ? raw.notes : '';
+    const dueDate = typeof raw.dueDate === 'string' ? raw.dueDate : '';
+    const priority = PRIORITY_SET.has(raw.priority) ? raw.priority : 'medium';
+    const recurrence = RECURRENCE_SET.has(raw.recurrence) ? raw.recurrence : 'none';
+    const category = CATEGORY_SET.has(raw.category) ? raw.category : 'work';
+    const status = raw.status === 'done' ? 'done' : 'todo';
+    const tags = Array.isArray(raw.tags) ? raw.tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim()) : [];
+    const createdAt = typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString();
+    const subtasks = Array.isArray(raw.subtasks)
+        ? raw.subtasks.map((st, subIndex) => {
+            const text = typeof st?.text === 'string' ? st.text.trim() : '';
+            if (!text) return null;
+            const subId = typeof st?.id === 'string' && st.id.trim() ? st.id.trim() : `sub_${id}_${subIndex}`;
+            return { id: subId, text, done: Boolean(st?.done) };
+        }).filter(Boolean)
+        : [];
+    return { id, title, notes, dueDate, priority, recurrence, category, status, tags, createdAt, subtasks };
+}
+
 // --- STAN APLIKACJI ---
 function loadState() {
-    const proDataRaw = localStorage.getItem(TASKS_STORAGE_KEY);
-    state = proDataRaw ? JSON.parse(proDataRaw) : { tasks: [] };
+    const parsed = safeParse(localStorage.getItem(TASKS_STORAGE_KEY), () => ({ tasks: [] }));
+    const rawTasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
+    const normalized = rawTasks.map(normalizeTask).filter(Boolean);
+    state = { tasks: normalized };
 }
 function saveState() { localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(state)); }
 
@@ -332,16 +446,253 @@ const modalOverlay = getEl('modal-overlay'), modalText = getEl('modal-text'), mo
 const statsSummaryEl = getEl('stats-summary');
 const statsRangeControl = getEl('stats-range-control');
 const statsCategoryControl = getEl('stats-category-control');
+const insightsGrid = getEl('insights-grid');
+const insightsEmpty = getEl('insights-empty');
+const heroActiveTasksEl = getEl('hero-tasks-active');
+const heroTotalNoteEl = getEl('hero-tasks-total-note');
+const heroWeekProgressEl = getEl('hero-week-progress');
+const heroWeekNoteEl = getEl('hero-week-note');
+const heroWeekChipEl = getEl('hero-week-chip');
+const heroOverdueChipEl = getEl('hero-overdue-chip');
+const heroOverdueEl = getEl('hero-overdue-count');
+const heroOverdueNoteEl = getEl('hero-overdue-note');
 
 const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 
 // --- GŁÓWNE FUNKCJE ---
 function render() {
+    updateHeroStats();
+    renderInsights();
     renderTaskList();
     const activeTabEl = document.querySelector('.tab.active');
     const activeTab = activeTabEl ? activeTabEl.dataset.tab : 'list';
     if (activeTab === 'calendar') renderCalendar();
     if (activeTab === 'stats') renderStats();
+}
+
+function formatDateShort(date) {
+    return date.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' });
+}
+
+function describeRelativeDate(target, base) {
+    const diffDays = Math.round((target.getTime() - base.getTime()) / DAY_IN_MS);
+    if (diffDays === 0) return 'dzisiaj';
+    if (diffDays === 1) return 'jutro';
+    if (diffDays === -1) return 'wczoraj';
+    const label = pluralize(Math.abs(diffDays), ['dzień', 'dni', 'dni']);
+    if (diffDays > 1) return `za ${diffDays} ${label}`;
+    return `${Math.abs(diffDays)} ${label} temu`;
+}
+
+function updateHeroStats() {
+    if (!heroActiveTasksEl) return;
+    const total = state.tasks.length;
+    const active = state.tasks.filter(task => task.status !== 'done').length;
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+
+    const weekStart = new Date(today);
+    const weekday = weekStart.getUTCDay();
+    const offset = (weekday + 6) % 7; // Monday as week start
+    weekStart.setUTCDate(weekStart.getUTCDate() - offset);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setUTCDate(weekEnd.getUTCDate() + 7);
+
+    let weekTotal = 0;
+    let weekDone = 0;
+    state.tasks.forEach(task => {
+        const due = parseDate(task.dueDate);
+        if (!due) return;
+        if (due >= weekStart && due < weekEnd) {
+            weekTotal += 1;
+            if (task.status === 'done') weekDone += 1;
+        }
+    });
+    const weekProgress = weekTotal ? Math.round((weekDone / weekTotal) * 100) : 0;
+
+    const overdueCount = state.tasks.filter(task => {
+        if (task.status === 'done') return false;
+        const due = parseDate(task.dueDate);
+        return due && due < today;
+    }).length;
+
+    heroActiveTasksEl.textContent = active;
+    heroTotalNoteEl.textContent = total
+        ? `${total} ${pluralize(total, ['zadanie w bazie', 'zadania w bazie', 'zadań w bazie'])}`
+        : 'Brak zadań w bazie';
+    heroWeekProgressEl.textContent = `${weekProgress}%`;
+    heroWeekNoteEl.textContent = weekTotal
+        ? `${weekDone} z ${weekTotal} zaplanowanych`
+        : 'Brak zadań na ten tydzień';
+    heroWeekChipEl.classList.remove('positive', 'negative', 'neutral');
+    const weekTone = !weekTotal ? 'neutral' : weekProgress >= 75 ? 'positive' : weekProgress < 40 ? 'negative' : 'neutral';
+    heroWeekChipEl.classList.add(weekTone);
+
+    heroOverdueEl.textContent = overdueCount;
+    heroOverdueNoteEl.textContent = overdueCount ? 'Potrzebują uwagi' : 'Brak zaległości';
+    heroOverdueChipEl.classList.remove('positive', 'negative', 'neutral');
+    heroOverdueChipEl.classList.add(overdueCount > 0 ? 'negative' : 'positive');
+}
+
+function priorityWeight(priority) {
+    if (priority === 'high') return 0;
+    if (priority === 'medium') return 1;
+    if (priority === 'low') return 2;
+    return 3;
+}
+
+function buildInsights() {
+    if (!state.tasks.length) return [];
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const weekAhead = new Date(today);
+    weekAhead.setUTCDate(weekAhead.getUTCDate() + 7);
+    const fortnightAhead = new Date(today);
+    fortnightAhead.setUTCDate(fortnightAhead.getUTCDate() + 14);
+
+    const pending = state.tasks.filter(task => task.status !== 'done');
+    const insights = [];
+
+    const overdue = pending
+        .filter(task => {
+            const due = parseDate(task.dueDate);
+            return due && due < today;
+        })
+        .sort((a, b) => parseDate(a.dueDate) - parseDate(b.dueDate));
+
+    if (overdue.length) {
+        const oldest = overdue[0];
+        const dueDate = parseDate(oldest.dueDate);
+        const relative = describeRelativeDate(dueDate, today);
+        insights.push({
+            tone: 'alert',
+            icon: '⚠️',
+            title: 'Pilne zaległości',
+            body: `Masz ${overdue.length} ${pluralize(overdue.length, ['zaległe zadanie', 'zaległe zadania', 'zaległych zadań'])}. Najstarsze („${oldest.title}”) było zaplanowane na ${formatDateShort(dueDate)} (${relative}).`
+        });
+    } else {
+        const completedCount = state.tasks.filter(task => task.status === 'done').length;
+        const message = completedCount
+            ? `Brawo! Brak zaległości. Zamknąłeś już ${completedCount} ${pluralize(completedCount, ['zadanie', 'zadania', 'zadań'])}.`
+            : 'Nie masz jeszcze zaległości — to idealny moment, aby zaplanować kolejne zadania.';
+        insights.push({
+            tone: 'success',
+            icon: '🌟',
+            title: 'Zaległości opanowane',
+            body: message
+        });
+    }
+
+    const upcoming = pending
+        .filter(task => {
+            const due = parseDate(task.dueDate);
+            return due && due >= today;
+        })
+        .sort((a, b) => {
+            const weightDiff = priorityWeight(a.priority) - priorityWeight(b.priority);
+            if (weightDiff !== 0) return weightDiff;
+            return parseDate(a.dueDate) - parseDate(b.dueDate);
+        });
+
+    if (upcoming.length) {
+        const nextTask = upcoming[0];
+        const dueDate = parseDate(nextTask.dueDate);
+        const relative = describeRelativeDate(dueDate, today);
+        const priorityLabel = { high: 'wysoki', medium: 'średni', low: 'niski' }[nextTask.priority] || 'średni';
+        insights.push({
+            tone: 'focus',
+            icon: '🎯',
+            title: 'Najbliższy priorytet',
+            body: `Skup się na „${nextTask.title}” (${priorityLabel} priorytet) — termin ${relative} (${formatDateShort(dueDate)}).`
+        });
+    }
+
+    const lastSevenStart = new Date(today);
+    lastSevenStart.setUTCDate(lastSevenStart.getUTCDate() - 6);
+    const completedRecent = state.tasks.filter(task => {
+        if (task.status !== 'done' || !task.dueDate) return false;
+        const due = parseDate(task.dueDate);
+        return due && due >= lastSevenStart && due <= today;
+    }).length;
+    const plannedWeek = pending.filter(task => {
+        if (!task.dueDate) return false;
+        const due = parseDate(task.dueDate);
+        return due && due >= today && due <= weekAhead;
+    }).length;
+    const progressDenominator = plannedWeek + completedRecent;
+    const progressRate = progressDenominator ? Math.round((completedRecent / progressDenominator) * 100) : 0;
+    const progressTone = completedRecent ? 'success' : 'focus';
+    let progressBody;
+    if (completedRecent) {
+        progressBody = `W ostatnich 7 dniach domknąłeś ${completedRecent} ${pluralize(completedRecent, ['zadanie', 'zadania', 'zadań'])}. W planie na kolejny tydzień czeka ${plannedWeek} ${pluralize(plannedWeek, ['zadanie', 'zadania', 'zadań'])} (realizacja na poziomie ${progressRate}%).`;
+    } else if (plannedWeek) {
+        progressBody = `Brak ukończonych zadań w tym tygodniu. Przed Tobą ${plannedWeek} ${pluralize(plannedWeek, ['zadanie', 'zadania', 'zadań'])} — zarezerwuj czas, aby wejść na właściwe tempo.`;
+    } else {
+        progressBody = 'To dobry moment, aby dodać zadania do harmonogramu tygodnia i utrzymać rytm pracy.';
+    }
+    insights.push({
+        tone: progressTone,
+        icon: completedRecent ? '✅' : '🧭',
+        title: 'Bilans tygodnia',
+        body: progressBody
+    });
+
+    const withoutDate = pending.filter(task => !task.dueDate).length;
+    const loadByCategory = pending.reduce((acc, task) => {
+        const due = parseDate(task.dueDate);
+        if (due && due >= today && due <= fortnightAhead) {
+            acc[task.category] = (acc[task.category] || 0) + 1;
+        }
+        return acc;
+    }, { work: 0, private: 0 });
+
+    if (loadByCategory.work || loadByCategory.private) {
+        const key = loadByCategory.work >= loadByCategory.private ? 'work' : 'private';
+        const count = loadByCategory[key];
+        const label = key === 'work' ? 'obszarze pracy' : 'strefie prywatnej';
+        insights.push({
+            tone: 'focus',
+            icon: key === 'work' ? '💼' : '🏡',
+            title: 'Plan na 2 tygodnie',
+            body: `Najbliższe 14 dni to ${count} ${pluralize(count, ['zadanie', 'zadania', 'zadań'])} w ${label}. Zaplanuj zasoby zawczasu.`
+        });
+    } else if (withoutDate) {
+        insights.push({
+            tone: 'focus',
+            icon: '🗓️',
+            title: 'Zadania bez terminu',
+            body: `${withoutDate} ${pluralize(withoutDate, ['zadanie', 'zadania', 'zadań'])} nie ma przypisanego terminu. Dodaj daty, aby utrzymać rytm pracy.`
+        });
+    } else if (!pending.length) {
+        insights.push({
+            tone: 'success',
+            icon: '🧘',
+            title: 'Gotowy na nowe cele',
+            body: 'Wszystkie zadania są ukończone. Dodaj nowe cele, aby utrzymać rozpęd.'
+        });
+    }
+
+    return insights.slice(0, 3);
+}
+
+function renderInsights() {
+    if (!insightsGrid) return;
+    const insights = buildInsights();
+    if (!insights.length) {
+        insightsGrid.innerHTML = '';
+        if (insightsEmpty) insightsEmpty.style.display = 'block';
+        return;
+    }
+    insightsGrid.innerHTML = insights.map(({ icon, title, body, tone }) => `
+        <article class="insight-card" data-tone="${tone}" role="listitem">
+          <div class="insight-icon" aria-hidden="true">${icon}</div>
+          <div class="insight-content">
+            <h4>${title}</h4>
+            <p>${body}</p>
+          </div>
+        </article>
+    `).join('');
+    if (insightsEmpty) insightsEmpty.style.display = 'none';
 }
 
 function parseDate(dateString) {

--- a/trainings.html
+++ b/trainings.html
@@ -4,79 +4,93 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS – Trainings</title>
+  <link rel="stylesheet" href="assets/styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
   <style>
 :root {
-  --bg: #eef2ff;
-  --bg-alt: #f8fafc;
-  --card: #ffffff;
-  --ink: #0f172a;
-  --muted: #64748b;
-  --line: #e2e8f0;
-  --primary: #2563eb;
-  --primary-soft: #eff6ff;
-  --primary-border: #bfdbfe;
-  --success: #0f9d58;
-  --success-soft: #ecfdf5;
-  --success-border: #bbf7d0;
-  --warning: #f59e0b;
-  --danger: #dc2626;
+  --bg-alt: var(--surface);
+  --primary: var(--accent);
+  --primary-soft: var(--accent-weak);
+  --primary-border: hsl(var(--accent-h) 55% 80% / 0.7);
+  --success: var(--green);
+  --success-soft: var(--green-soft);
+  --success-border: hsl(152 62% 80% / 0.65);
+  --warning: var(--orange);
+  --danger: var(--red);
   --shadow-sm: 0 12px 30px rgba(15, 23, 42, 0.08);
   --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.12);
   --transition: all .2s ease;
-  --gym-color: #5b21b6;
-  --run-color: #047857;
-  --read-color: #1d4ed8;
+  --gym-color: hsl(var(--accent-h) 65% 42%);
+  --run-color: var(--green);
+  --read-color: var(--accent);
   --extra-color: #0ea5e9;
   --day-empty: #fff1f2;
   --day-empty-border: rgba(248, 113, 113, 0.5);
   --day-planned: #fff7ed;
   --day-planned-border: rgba(251, 191, 36, 0.45);
-  --day-completed: #ecfdf5;
+  --day-completed: var(--green-soft);
   --day-completed-border: rgba(34, 197, 94, 0.45);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: linear-gradient(160deg, #e0e7ff 0%, #f1f5f9 45%, #ffffff 100%);
-  color: var(--ink);
-  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
-  font-size: 13px;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-}
-
-h1, h2, h3, h4, h5 { margin: 0; color: var(--ink); }
-p { margin: 0; }
-
-.wrap {
-  max-width: 1360px;
-  margin: 0 auto;
-  padding: 28px 32px 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-a { color: inherit; text-decoration: none; }
-
-.card {
-  background: var(--card);
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  padding: 20px 24px;
-  box-shadow: var(--shadow-sm);
 }
 
 .page-content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 32px;
+}
+
+.module-title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.month-switcher {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.month-switcher .month-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  min-width: 140px;
+}
+
+.month-switcher .month-label {
+  font-size: 18px;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.icon-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.icon-btn .icon {
+  width: 18px;
+  height: 18px;
+}
+
+.icon-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+  border-color: hsl(var(--accent-h) 45% 75%);
 }
 
 .top-grid {
@@ -170,6 +184,7 @@ a { color: inherit; text-decoration: none; }
 }
 
 .title-block { display: flex; flex-direction: column; gap: 6px; }
+.title-block .back-link { align-self: flex-start; }
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -183,56 +198,20 @@ a { color: inherit; text-decoration: none; }
 
 .page-header-actions { display: flex; gap: 10px; align-items: center; }
 
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 14px;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 12px;
-  border: 1px solid transparent;
-  background: var(--ink);
-  color: #fff;
-  cursor: pointer;
-  transition: var(--transition);
+.btn.icon-btn {
+  width: 40px;
+  height: 40px;
+  padding: 0;
 }
 
-.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
-.btn .icon { width: 16px; height: 16px; }
-.btn.soft { background: #fff; color: var(--ink); border-color: rgba(148, 163, 184, 0.45); }
-.btn.soft:hover { border-color: var(--primary); color: var(--primary); }
-.btn.ghost { background: rgba(148, 163, 184, 0.16); color: var(--ink); }
-.btn.ghost:hover { background: rgba(148, 163, 184, 0.3); }
-.btn.ghost.active { background: rgba(148, 163, 184, 0.28); border-color: rgba(148, 163, 184, 0.5); }
-.btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow: none; }
-
-.icon-btn {
-  width: 38px;
-  height: 38px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #fff;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: var(--transition);
-  color: var(--ink);
+.btn.icon-btn .icon {
+  width: 18px;
+  height: 18px;
 }
-
-.icon-btn:hover { border-color: var(--primary); color: var(--primary); transform: translateY(-1px); box-shadow: var(--shadow-sm); }
 
 .icon { width: 16px; height: 16px; }
 
-.month-bar { display: flex; justify-content: space-between; align-items: center; }
-.month-controls { display: flex; align-items: center; gap: 12px; }
-.month-labels { display: flex; flex-direction: column; gap: 4px; align-items: center; }
-.month-labels h2 { font-size: 20px; font-weight: 700; text-transform: capitalize; }
-.month-range { font-size: 12px; color: var(--muted); }
-
-.month-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--primary-soft); color: var(--primary); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+.month-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--primary-soft); color: var(--accent); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
 
 .metrics-row {
   display: grid;
@@ -668,35 +647,62 @@ a { color: inherit; text-decoration: none; }
 }
   </style>
 </head>
-<body>
-<div class="wrap">
-  <header class="page-header card">
-    <div class="page-header-top">
-      <div class="title-block">
-        <span class="eyebrow">Program treningowy</span>
-        <div class="title-row">
-          <h1>Panel treningów</h1>
-          <span class="month-chip" id="header-month-chip">--</span>
+<body class="module-shell">
+  <section class="module-hero">
+    <div class="wrap module-hero-inner">
+      <div class="module-hero-top">
+        <div class="module-hero-meta">
+          <a href="./index.html" class="back-link">← Powrót</a>
+          <div class="module-title-block">
+            <div class="module-eyebrow">Program treningowy</div>
+            <div class="module-title-row">
+              <h1 class="module-title">Panel treningów</h1>
+              <span class="chip" id="header-month-chip">--</span>
+            </div>
+            <p class="module-subtitle">Zarządzaj planem aktywności, dniami urlopu i monitoruj realizację celów.</p>
+          </div>
+        </div>
+        <div class="module-hero-actions month-switcher">
+          <button id="prev-month-btn" class="btn ghost icon-btn" aria-label="Poprzedni miesiąc"><i data-lucide="chevron-left" class="icon"></i></button>
+          <div class="month-labels">
+            <span class="month-label" id="current-month-label">--</span>
+            <span class="tiny muted" id="current-month-range">--</span>
+          </div>
+          <button id="next-month-btn" class="btn ghost icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
+          <button id="today-month-btn" class="btn soft"><i data-lucide="calendar" class="icon"></i>Dzisiaj</button>
         </div>
       </div>
-      <div class="page-header-actions">
-        <a href="./index.html" class="btn ghost"><i data-lucide="arrow-left" class="icon"></i>Powrót</a>
-        <button id="today-month-btn" class="btn soft"><i data-lucide="calendar" class="icon"></i>Dzisiaj</button>
-      </div>
-    </div>
-    <div class="month-bar">
-      <div class="month-controls">
-        <button id="prev-month-btn" class="icon-btn" aria-label="Poprzedni miesiąc"><i data-lucide="chevron-left" class="icon"></i></button>
-        <div class="month-labels">
-          <h2 id="current-month-label">--</h2>
-          <span class="month-range muted" id="current-month-range">--</span>
+      <div class="module-hero-stats">
+        <div class="module-hero-stat positive" id="hero-goal-chip">
+          <span class="emoji">🎯</span>
+          <div class="stat-body">
+            <span class="label">Realizacja celów</span>
+            <span class="value" id="hero-goal-progress">0%</span>
+            <span class="note" id="hero-goal-progress-note">Cele tygodniowe — --</span>
+          </div>
         </div>
-        <button id="next-month-btn" class="icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
+        <div class="module-hero-stat neutral" id="hero-weekly-chip">
+          <span class="emoji">📆</span>
+          <div class="stat-body">
+            <span class="label">Zaliczone tygodnie</span>
+            <span class="value" id="hero-weekly-complete-count">0/0</span>
+            <span class="note" id="hero-weekly-complete-note">0%</span>
+          </div>
+        </div>
+        <div class="module-hero-stat neutral" id="hero-active-chip">
+          <span class="emoji">🏃</span>
+          <div class="stat-body">
+            <span class="label">Aktywne dni</span>
+            <span class="value" id="hero-active-days">0/0</span>
+            <span class="note" id="hero-active-days-note">W tym miesiącu</span>
+          </div>
+        </div>
       </div>
     </div>
-  </header>
+  </section>
 
-  <main class="page-content">
+  <main class="module-content">
+    <div class="wrap page-content">
     <div class="top-grid">
       <section class="card metrics-card">
         <div class="metrics-header">
@@ -855,8 +861,8 @@ a { color: inherit; text-decoration: none; }
         <span>Intensywnie</span>
       </div>
     </section>
+  </div>
   </main>
-</div>
 
 <div id="modal-overlay" class="modal-overlay">
   <div class="modal-card">
@@ -895,6 +901,17 @@ const MAX_CALENDAR_TAGS = 4;
 const DEFAULT_PLANNING_META = 'Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DONUT_CIRCUMFERENCE = 2 * Math.PI * 16;
+
+const safeParse = (raw, fallbackFactory) => {
+  const fallback = () => (typeof fallbackFactory === 'function' ? fallbackFactory() : fallbackFactory);
+  if (!raw) return fallback();
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : fallback();
+  } catch {
+    return fallback();
+  }
+};
 
 let state = { activities: {}, extras: {}, vacations: {} };
 let currentMonth = startOfMonth(new Date());
@@ -1133,18 +1150,11 @@ function getISOWeekInfo(date) {
 function loadState() {
   state = { activities: {}, extras: {}, vacations: {} };
   planningMode = null;
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === 'object') {
-        state.activities = parsed.activities && typeof parsed.activities === 'object' ? parsed.activities : {};
-        state.extras = parsed.extras && typeof parsed.extras === 'object' ? parsed.extras : {};
-        state.vacations = parsed.vacations && typeof parsed.vacations === 'object' ? parsed.vacations : {};
-      }
-    }
-  } catch (error) {
-    state = { activities: {}, extras: {}, vacations: {} };
+  const parsed = safeParse(localStorage.getItem(STORAGE_KEY), () => ({}));
+  if (parsed && typeof parsed === 'object') {
+    state.activities = parsed.activities && typeof parsed.activities === 'object' ? parsed.activities : {};
+    state.extras = parsed.extras && typeof parsed.extras === 'object' ? parsed.extras : {};
+    state.vacations = parsed.vacations && typeof parsed.vacations === 'object' ? parsed.vacations : {};
   }
   migrateLegacyState();
 }
@@ -1162,7 +1172,7 @@ function migrateLegacyState() {
     if (localStorage.getItem(MIGRATION_FLAG_KEY)) return;
     const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
     if (!legacyRaw) return;
-    const legacyState = JSON.parse(legacyRaw);
+    const legacyState = safeParse(legacyRaw, () => null);
     if (!legacyState || typeof legacyState !== 'object') {
       localStorage.setItem(MIGRATION_FLAG_KEY, 'done');
       return;
@@ -1500,23 +1510,38 @@ function renderHeader(monthStats, weekStats, upcomingWindow, yearStats) {
   const todayButton = document.getElementById('today-month-btn');
   if (sameMonth(new Date(), currentMonth)) todayButton.style.display = 'none';
   else todayButton.style.display = 'inline-flex';
-  document.getElementById('metric-goal-progress').textContent = `${weekStats.averageGoalPercent}%`;
+  const weeklyPercentLabel = `${weekStats.averageGoalPercent}%`;
+  document.getElementById('metric-goal-progress').textContent = weeklyPercentLabel;
+  const heroGoalProgress = document.getElementById('hero-goal-progress');
+  if (heroGoalProgress) heroGoalProgress.textContent = weeklyPercentLabel;
   const goalProgressSub = document.getElementById('metric-goal-progress-sub');
+  const weeklyRange = weekStats && weekStats.range ? formatRange(weekStats.range.start, weekStats.range.end) : '--';
   if (goalProgressSub) {
-    if (weekStats && weekStats.range) {
-      goalProgressSub.innerHTML = `<span class="metric-subline">Cele tygodniowe</span><span class="metric-subline">${formatRange(weekStats.range.start, weekStats.range.end)}</span>`;
-    } else {
-      goalProgressSub.innerHTML = `<span class="metric-subline">Cele tygodniowe</span><span class="metric-subline">--</span>`;
-    }
+    goalProgressSub.innerHTML = `<span class="metric-subline">Cele tygodniowe</span><span class="metric-subline">${weeklyRange}</span>`;
   }
-  document.getElementById('metric-plan-completion').textContent = `${monthStats.completedCount}/${monthStats.plannedCount}`;
+  const heroGoalNote = document.getElementById('hero-goal-progress-note');
+  if (heroGoalNote) heroGoalNote.textContent = `Cele tygodniowe — ${weeklyRange}`;
+  const planCompletionLabel = `${monthStats.completedCount}/${monthStats.plannedCount}`;
+  document.getElementById('metric-plan-completion').textContent = planCompletionLabel;
   document.getElementById('metric-active-days').textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
+  const heroActiveDays = document.getElementById('hero-active-days');
+  if (heroActiveDays) heroActiveDays.textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
+  const heroActiveNote = document.getElementById('hero-active-days-note');
+  if (heroActiveNote) heroActiveNote.textContent = `Ukończone ${monthStats.completedCount.toLocaleString('pl-PL')} działań`;
   const countEl = document.getElementById('metric-weekly-complete-count');
   if (countEl && yearStats) {
     const completedLabel = `${yearStats.completedWeeks.toLocaleString('pl-PL')}/${yearStats.totalWeeks.toLocaleString('pl-PL')}`;
     countEl.textContent = completedLabel;
   } else if (countEl) {
     countEl.textContent = '0/0';
+  }
+  const heroWeeklyCount = document.getElementById('hero-weekly-complete-count');
+  if (heroWeeklyCount) {
+    if (yearStats) {
+      heroWeeklyCount.textContent = `${yearStats.completedWeeks.toLocaleString('pl-PL')}/${yearStats.totalWeeks.toLocaleString('pl-PL')}`;
+    } else {
+      heroWeeklyCount.textContent = '0/0';
+    }
   }
   const subEl = document.getElementById('metric-weekly-complete-sub');
   if (subEl) {
@@ -1530,11 +1555,13 @@ function renderHeader(monthStats, weekStats, upcomingWindow, yearStats) {
     }
   }
   const percentEl = document.getElementById('metric-weekly-complete-percent');
+  const heroWeeklyNote = document.getElementById('hero-weekly-complete-note');
+  const value = yearStats ? yearStats.percent : 0;
+  const formatted = Number(value).toLocaleString('pl-PL', { maximumFractionDigits: 0 });
   if (percentEl) {
-    const value = yearStats ? yearStats.percent : 0;
-    const formatted = Number(value).toLocaleString('pl-PL', { maximumFractionDigits: 0 });
     percentEl.textContent = `${formatted}%`;
   }
+  if (heroWeeklyNote) heroWeeklyNote.textContent = `${formatted}% wykonania`;
   const circle = document.getElementById('metric-weekly-complete-circle');
   if (circle) {
     const safePercent = yearStats ? Math.max(0, Math.min(100, yearStats.percent)) : 0;


### PR DESCRIPTION
## Summary
- restyled the shared module hero into compact emoji chips for consistent headers across budget, loan, house, tasks, trainings, and fuel
- reworked the fuel module to surface entry forms first, add lighter KPI chips, and drive hero/insight metrics from a shared 12‑month calculation
- moved the task creator ahead of insights and toned hero chips based on current progress and overdue load

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68cf22b548331ab63125984494414